### PR TITLE
Add just modules, Lua 5.1 tooling, and editor integration

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
+  "workspace": {
+    "ignoreDir": [".devtools"]
+  }
+}

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
-  "workspace": {
-    "ignoreDir": [".devtools"]
-  }
-}

--- a/Justfile
+++ b/Justfile
@@ -5,6 +5,14 @@ mod repos    'just/repos.just'
 mod engine   'just/engine.just'
 mod setup    'just/setup.just'
 mod link     'just/link.just'
+mod lua      'just/lua.just'
+mod docs     'just/docs.just'
+mod bar      'just/bar.just'
+mod tei      'just/tei.just'
 
 default:
     @just --list --list-submodules
+
+reset:
+    just lua::reset
+    just docs::reset

--- a/README.md
+++ b/README.md
@@ -7,10 +7,20 @@ Everything server-side runs in Docker. The game client runs natively.
 ## Quick Start
 
 ```bash
+# Install just
+pacman -S just        # Arch
+dnf install just      # Fedora
+apt install just      # Debian/Ubuntu
+```
+
+```bash
+# Run setup
 git clone https://github.com/thvl3/BAR-Devtools.git
 cd BAR-Devtools
 just setup::init
 just services::up
+# recommended
+just setup::editor    # export clangd + generate compile_commands.json
 ```
 
 `setup::init` walks you through installing dependencies, cloning repositories, and building Docker images. You only need to run it once.
@@ -37,13 +47,6 @@ Once running:
 - **[just](https://github.com/casey/just)** -- command runner
 - **[distrobox](https://distrobox.it/)** (recommended) -- dev toolchain container
 
-```bash
-# Install just
-pacman -S just        # Arch
-dnf install just      # Fedora
-apt install just      # Debian/Ubuntu
-```
-
 `just setup::deps` will detect your distro and install what's missing (except `just` itself).
 
 ### Dev environment (distrobox)
@@ -52,7 +55,7 @@ All dev tools (Lua 5.1, [Lux](https://github.com/lumen-oss/lux), Node.js, Cargo,
 
 Running `just setup::init` will offer to build the image and create a distrobox for you. Recipes that need these tools (`bar::lint`, `bar::fmt`, `bar::units`, `lua::library`, etc.) automatically enter the distrobox when `DEVTOOLS_DISTROBOX` is set in `.env`.
 
-To set up the distrobox standalone:
+To set up a new distrobox standalone:
 
 ```bash
 just setup::distrobox
@@ -60,16 +63,39 @@ just setup::distrobox
 
 ### Editor integration (VS Code / Cursor)
 
-Language servers like clangd are installed inside the distrobox. To make your editor use them, export the binaries to your host PATH with `distrobox-export`:
+Language servers and formatters live inside the distrobox. One command exports them to your host and generates `compile_commands.json` for engine C++ support:
 
 ```bash
-distrobox enter bar-dev
-
-# Inside the distrobox:
-distrobox-export --bin /usr/bin/clangd --export-path ~/.local/bin
+just setup::editor
 ```
 
-This creates thin wrapper scripts in `~/.local/bin` that transparently enter the distrobox when called. Your editor finds them on PATH and everything works as if they were installed natively.
+This exports `emmylua_ls`, `clangd`, and `stylua` as wrapper scripts in `~/.local/bin` (via `distrobox-export`), and runs `cmake` against RecoilEngine to produce `compile_commands.json` for clangd. Your editor finds the wrappers on PATH and everything works as if installed natively.
+
+### Git hooks
+
+Install a pre-commit hook that runs `stylua` (formatting) and `luacheck` (linting) on every commit:
+
+```bash
+just setup::hooks
+```
+
+**Recommended extensions:**
+
+* [EmmyLua](https://marketplace.visualstudio.com/items?itemName=tangzx.emmylua) (Lua language server -- Cursor users: install from VSIX, the marketplace version is outdated)
+* [StyLua](https://marketplace.visualstudio.com/items?itemName=JohnnyMorganz.stylua) (Lua formatter)
+* [clangd](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd) (C/C++ for engine work)
+
+**Settings** (JSON):
+
+```json
+{
+  "emmylua.ls.executablePath": "~/.local/bin/emmylua_ls",
+  "[lua]": {
+    "editor.defaultFormatter": "JohnnyMorganz.stylua",
+    "editor.formatOnSave": true
+  }
+}
+```
 
 #### VS Code Test Switcher (optional)
 
@@ -117,7 +143,9 @@ Run `just` with no arguments for the full recipe list.
 just bar::fmt           # format with stylua
 just bar::lint          # lint with luacheck
 just bar::units         # run busted unit tests
-just bar::test-shell    # interactive busted shell, run `busted -t focus` to test specs tagged #focus
+just bar::test-shell    # interactive busted shell,
+                        #   run `busted -t focus` to test specs tagged "#focus"
+                        #   for example: `it "should do something #focus", function()`
 ```
 
 ### Engine development
@@ -141,6 +169,7 @@ just services::up               # start PostgreSQL + Teiserver
 just services::up lobby spads   # ...with bar-lobby and SPADS
 just services::down             # stop everything
 just services::logs teiserver   # tail logs
+just tei::mix                   # run teiserver mix tests
 ```
 
 ## Using Your Own Forks
@@ -171,7 +200,7 @@ just repos::clone core
 You can also point a repo entry at a local directory instead of cloning. Add a fifth column with the path:
 
 ```
-lua-doc-extractor  https://github.com/rhys-vdw/lua-doc-extractor.git  main  extra  ~/code/lua-doc-extractor
+lua-doc-extractor  https://github.com/rhys-vdw/lua-doc-extractor.git  your-branch  extra  ~/code/lua-doc-extractor
 ```
 
 This creates a symlink instead of cloning.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -78,6 +78,18 @@ services:
       - spads_cache:/opt/spads/var
       - spring_engines:/spring-engines
 
+  recoil-docs:
+    build:
+      context: ./RecoilEngine/doc/site
+      dockerfile: ../../../docker/recoil-docs.Dockerfile
+    platform: linux/amd64
+    profiles: ["docs"]
+    volumes:
+      - ./RecoilEngine:/recoil:z
+    working_dir: /recoil/doc/site
+    ports:
+      - "1313:1313"
+
 volumes:
   pgdata:
   devtools_state:

--- a/docker/dev.Containerfile
+++ b/docker/dev.Containerfile
@@ -8,7 +8,12 @@ RUN dnf install -y --setopt=install_weak_deps=False \
         nodejs npm \
         rust cargo \
         clang-tools-extra cmake \
+        just \
         gcc gcc-c++ make git curl jq unzip binutils \
+        SDL2-devel DevIL-devel glew-devel openal-soft-devel \
+        libvorbis-devel freetype-devel fontconfig-devel \
+        libunwind-devel libcurl-devel jsoncpp-devel minizip-devel \
+        expat-devel libXcursor-devel p7zip \
     && dnf clean all \
     && ln -s /usr/bin/lua-5.1 /usr/local/bin/lua
 
@@ -35,5 +40,13 @@ RUN ARCH=$(uname -m) \
     && unzip -o /tmp/stylua.zip -d /usr/local/bin \
     && chmod +x /usr/local/bin/stylua \
     && rm /tmp/stylua.zip
+
+ARG EMMYLUA_VERSION=latest
+RUN ARCH=$(uname -m) \
+    && case "$ARCH" in x86_64) PLAT=linux-x64;; aarch64) PLAT=linux-arm64;; esac \
+    && URL=$(curl -fsSL "https://api.github.com/repos/EmmyLuaLs/emmylua-analyzer-rust/releases/${EMMYLUA_VERSION}" \
+       | jq -r --arg plat "emmylua_ls-${PLAT}.tar.gz" '.assets[] | select(.name == $plat) | .browser_download_url') \
+    && curl -fsSL "$URL" | tar xz -C /usr/local/bin \
+    && chmod +x /usr/local/bin/emmylua_ls
 
 LABEL com.github.containers.toolbox="true"

--- a/docker/recoil-docs.Dockerfile
+++ b/docker/recoil-docs.Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl git \
+        build-essential pkg-config \
+        libssl-dev zlib1g-dev libyaml-dev libffi-dev libreadline-dev \
+        p7zip-full \
+        libsdl2-2.0-0 libxcursor1 libx11-6 libopenal1 \
+    && rm -rf /var/lib/apt/lists/*
+
+SHELL ["/bin/bash", "-c"]
+
+RUN curl https://mise.run | sh
+ENV PATH="/root/.local/bin:/root/.local/share/mise/shims:${PATH}"
+
+WORKDIR /recoil/doc/site
+COPY mise.toml mise.ci.toml ./
+
+RUN mise trust . && \
+    mise use -g node@lts rust@stable go@latest && \
+    MISE_ENV=ci mise install
+
+COPY go.mod go.sum hugo.toml ./
+RUN MISE_ENV=ci mise exec -- hugo mod get
+
+ENTRYPOINT ["mise", "run"]

--- a/just/bar.just
+++ b/just/bar.just
@@ -1,0 +1,122 @@
+set export
+
+DEVTOOLS_DIR        := justfile_directory()
+COMPOSE_FILE        := DEVTOOLS_DIR / "docker-compose.dev.yml"
+COMPOSE             := "docker compose -f " + COMPOSE_FILE
+BAR_DIR             := DEVTOOLS_DIR / "Beyond-All-Reason"
+INTEGRATION_COMPOSE := "docker compose -f " + BAR_DIR / "tools" / "headless_testing" / "docker-compose.yml"
+LUALS_VERSION       := "3.17.1"
+LUALS_DIR           := DEVTOOLS_DIR / ".devtools" / "lua-language-server"
+LUALS_BIN           := LUALS_DIR / "bin" / "lua-language-server"
+
+[private]
+require-bar:
+    #!/usr/bin/env bash
+    if [ ! -d "{{BAR_DIR}}" ]; then
+        echo "Error: Beyond-All-Reason is not cloned." >&2
+        echo "Run: just repos::clone extra" >&2
+        exit 1
+    fi
+
+[private]
+require-luals:
+    #!/usr/bin/env bash
+    [ -x "{{LUALS_BIN}}" ] && exit 0
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    step "lua-language-server not found, downloading v{{LUALS_VERSION}}..."
+    mkdir -p "{{LUALS_DIR}}"
+    ARCH="$(uname -m)"
+    case "$ARCH" in
+        x86_64)  PLAT="linux-x64" ;;
+        aarch64) PLAT="linux-arm64" ;;
+        *)       err "Unsupported arch: $ARCH"; exit 1 ;;
+    esac
+    curl -fsSL "https://github.com/LuaLS/lua-language-server/releases/download/${LUALS_VERSION}/lua-language-server-${LUALS_VERSION}-${PLAT}.tar.gz" \
+        | tar xz -C "{{LUALS_DIR}}"
+    ok "Downloaded lua-language-server v{{LUALS_VERSION}}"
+
+# Type-check BAR Lua code (LuaLS diagnostics)
+check *args: require-bar require-luals
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    step "Running LuaLS type check..."
+    cd "$BAR_DIR"
+    "{{LUALS_BIN}}" --check=. --checklevel=Warning --logpath=/tmp/luals-check {{args}}
+    ok "Type check complete"
+
+# Lint BAR Lua code (luacheck via lux)
+lint *args: require-bar
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    enter_distrobox
+    (cd "$BAR_DIR" && lx --lua-version 5.1 lint {{args}})
+
+# Format BAR Lua code (stylua via lux)
+fmt *args: require-bar
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    enter_distrobox
+    (cd "$BAR_DIR" && lx --lua-version 5.1 exec stylua . {{args}})
+
+# Run busted unit tests
+units *args: require-bar
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    enter_distrobox
+    (cd "$BAR_DIR" && lx --lua-version 5.1 test {{args}})
+
+# Drop into an interactive test shell (busted on PATH)
+test-shell: require-bar
+    #!/usr/bin/env bash
+    set -e
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    cd "$BAR_DIR"
+    echo -e "${GREEN}[ok]${NC}    Entering lx test shell (busted is available)."
+    echo -e "${GREEN}[ok]${NC}    Type 'exit' to return."
+    if [ -n "${DEVTOOLS_DISTROBOX:-}" ] && [ -z "${_DEVTOOLS_IN_DISTROBOX:-}" ] && [ ! -f /run/.containerenv ]; then
+        exec script -qec "distrobox enter '${DEVTOOLS_DISTROBOX}' -- lx --lua-version 5.1 shell --test --no-loader" /dev/null
+    fi
+    exec lx --lua-version 5.1 shell --test --no-loader
+
+# Run headless integration tests (x86-64 only)
+integrations *args: require-bar
+    #!/usr/bin/env bash
+    if [[ "$(uname -m)" == arm64 ]]; then
+        echo "Error: integration tests require an x86-64 host." >&2
+        echo "The Spring engine used by headless tests has no arm64 build." >&2
+        exit 1
+    fi
+    {{INTEGRATION_COMPOSE}} up --build --abort-on-container-exit {{args}}
+
+# Run all BAR tests (unit + integrations)
+test: units integrations
+
+# Install git pre-commit hook in the BAR repo
+setup-hooks:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    hook="$BAR_DIR/.git/hooks/pre-commit"
+    if [ ! -d "$BAR_DIR/.git" ]; then
+        err "BAR repo not found at $BAR_DIR"
+        info "Clone it first: just repos::clone extra"
+        exit 1
+    fi
+    mkdir -p "$(dirname "$hook")"
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'set -e' \
+        'echo "[pre-commit] Running stylua..."' \
+        'lx --lua-version 5.1 exec stylua .' \
+        > "$hook"
+    chmod +x "$hook"
+    ok "Installed pre-commit hook at $hook"
+    if [ -f "$BAR_DIR/.git-blame-ignore-revs" ]; then
+        git -C "$BAR_DIR" config blame.ignoreRevsFile .git-blame-ignore-revs
+        ok "Configured git blame to ignore formatting commits"
+    fi

--- a/just/docs.just
+++ b/just/docs.just
@@ -1,0 +1,37 @@
+set export
+
+DEVTOOLS_DIR := justfile_directory()
+RECOIL_DIR   := DEVTOOLS_DIR / "RecoilEngine"
+COMPOSE_FILE := DEVTOOLS_DIR / "docker-compose.dev.yml"
+COMPOSE      := "docker compose -f " + COMPOSE_FILE
+
+# Generate Lua API pages (full pipeline: extract -> JSON -> markdown)
+generate:
+    {{COMPOSE}} run --rm recoil-docs lua_pages
+
+# Generate everything then start Hugo dev server
+server:
+    {{COMPOSE}} run --rm --service-ports recoil-docs server_full -- --bind 0.0.0.0
+
+# Start Hugo dev server without regenerating
+server-only:
+    {{COMPOSE}} run --rm --service-ports recoil-docs server -- --bind 0.0.0.0
+
+# Rebuild the docs container image
+build:
+    {{COMPOSE}} build recoil-docs
+
+#   TODO: Same workaround as lua::reset. doc/site/data/* are pipeline outputs tracked in git, so
+#         local docs generation dirties the tree. Prefer these as build-only artifacts (CI publishes
+#         them) rather than tracked outputs developers must constantly revert.
+
+# Reset generated doc data files
+reset:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    info "Resetting doc site data in RecoilEngine..."
+    cd "$RECOIL_DIR"
+    git checkout -- doc/site/data/
+    git clean -fd doc/site/data/
+    ok "Doc data reset."

--- a/just/engine.just
+++ b/just/engine.just
@@ -22,4 +22,4 @@ build *args:
         echo "    just engine::build --help"
         exit 1
     fi
-    exec "$build_script" {{args}}
+    exec bash "$build_script" {{args}}

--- a/just/lua.just
+++ b/just/lua.just
@@ -1,0 +1,105 @@
+set export
+
+DEVTOOLS_DIR := justfile_directory()
+RECOIL_DIR   := DEVTOOLS_DIR / "RecoilEngine"
+BAR_DIR      := DEVTOOLS_DIR / "Beyond-All-Reason"
+LDE_DIR      := DEVTOOLS_DIR / "lua-doc-extractor"
+
+# Build lua-doc-extractor from local checkout
+build-lde:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    if [ ! -d "$LDE_DIR" ]; then
+        err "lua-doc-extractor not found at $LDE_DIR"
+        info "Clone it first: just repos::clone extra"
+        exit 1
+    fi
+    cd "$LDE_DIR"
+    npm ci && npm run build
+    ok "lua-doc-extractor built"
+
+# Resolve the lux-installed path for recoil-lua-library
+[private]
+recoil-lib-path:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    match=$(find "$BAR_DIR/.lux/5.1" -maxdepth 2 -name 'src' -path '*recoil-lua-library*' -type d 2>/dev/null | head -1)
+    if [ -z "$match" ]; then
+        echo "$BAR_DIR/.lux/5.1/recoil-lua-library" # fallback before first sync
+    else
+        dirname "$match"
+    fi
+
+# Create symlink from BAR/recoil-lua-library -> lux-installed package
+link: recoil-lib-path
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    target=$(just lua::recoil-lib-path)
+    link="$BAR_DIR/recoil-lua-library"
+    if [ -L "$link" ]; then
+        rm "$link"
+    elif [ -e "$link" ]; then
+        warn "$link exists and is not a symlink, skipping"
+        exit 0
+    fi
+    ln -s "$target" "$link"
+    ok "Symlinked $link -> $target"
+
+# Generate Lua library from RecoilEngine sources, copy into lux-installed path
+library *flags: build-lde
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    LIB="$RECOIL_DIR/rts/Lua/library"
+    DEST="$LIB/generated"
+
+    info "Cleaning stale generated files..."
+    clean_dir "$DEST"
+    clean_dir "$LIB/RecoilEngine"
+
+    enter_distrobox
+    LDE="node $LDE_DIR/dist/src/cli.js"
+
+    info "Extracting Lua docs..."
+    $LDE \
+        --src "$RECOIL_DIR/rts/{Lua,Rml/SolLua}/**/*.cpp" \
+        --dest "$DEST" \
+        --repo "https://github.com/beyond-all-reason/RecoilEngine/blob/master" \
+        {{flags}}
+
+    LUX_LIB=$(just lua::recoil-lib-path 2>/dev/null || echo "")
+    if [ -n "$LUX_LIB" ] && [ -d "$LUX_LIB" ]; then
+        info "Copying into lux-installed recoil-lua-library..."
+        clean_dir "$LUX_LIB/src"
+        mkdir -p "$LUX_LIB/src"
+        cp -r "$RECOIL_DIR/rts/Lua/library/"* "$LUX_LIB/src/"
+        ok "Updated $LUX_LIB/src/"
+        echo "  Run 'just lua::reset' to restore the published version."
+    else
+        info "Copying into BAR working tree..."
+        mkdir -p "$BAR_DIR/recoil-lua-library/src"
+        cp -r "$RECOIL_DIR/rts/Lua/library/"* "$BAR_DIR/recoil-lua-library/src/"
+        ok "Updated $BAR_DIR/recoil-lua-library/src/"
+    fi
+
+# Generate library then restart LuaLS so the editor picks up changes
+library-reload *flags: (library flags)
+    -pkill -f lua-language-server
+    @echo "LuaLS restarting (editor extension will respawn it)"
+
+# Reset generated Lua library files and restore lux-installed version
+reset:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    info "Resetting Lua library in RecoilEngine..."
+    cd "$RECOIL_DIR"
+    git checkout -- rts/Lua/library/
+    git clean -fd rts/Lua/library/
+    info "Restoring lux-installed recoil-lua-library..."
+    cd "$BAR_DIR"
+    lx sync
+    just lua::link
+    ok "Lua library reset."

--- a/just/setup.just
+++ b/just/setup.just
@@ -31,6 +31,53 @@ distrobox:
     source "$DEVTOOLS_DIR/scripts/setup.sh"
     cmd_setup_distrobox
 
+# Export distrobox binaries for editor integration (clangd, emmylua_ls, stylua)
+editor:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    if [ -z "${DEVTOOLS_DISTROBOX:-}" ]; then
+        err "DEVTOOLS_DISTROBOX not set. Run: just setup::distrobox"
+        exit 1
+    fi
+    local_bin="$HOME/.local/bin"
+    mkdir -p "$local_bin"
+    for bin in /usr/local/bin/emmylua_ls /usr/bin/clangd /usr/local/bin/stylua; do
+        name="$(basename "$bin")"
+        info "Exporting $name..."
+        distrobox enter "$DEVTOOLS_DISTROBOX" -- distrobox-export --bin "$bin" --export-path "$local_bin"
+    done
+    echo ""
+    if [ -f "$DEVTOOLS_DIR/RecoilEngine/CMakeLists.txt" ]; then
+        step "Generating compile_commands.json for clangd..."
+        distrobox enter "$DEVTOOLS_DISTROBOX" -- bash -c "
+            cd '$DEVTOOLS_DIR/RecoilEngine' \
+            && mkdir -p build \
+            && cd build \
+            && cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .. 2>&1 | tail -3
+        "
+        ln -sf build/compile_commands.json "$DEVTOOLS_DIR/RecoilEngine/compile_commands.json"
+        ok "compile_commands.json ready"
+    else
+        info "RecoilEngine not cloned — skipping compile_commands.json"
+    fi
+    echo ""
+    ok "Editor integration ready."
+    echo ""
+    info "Install these VS Code / Cursor extensions:"
+    echo "  - EmmyLua (tangzx.emmylua) — Cursor users: install from VSIX, marketplace version is outdated"
+    echo "    https://marketplace.visualstudio.com/items?itemName=tangzx.emmylua"
+    echo "  - StyLua (JohnnyMorganz.stylua)"
+    echo "  - clangd (llvm-vs-code-extensions.vscode-clangd) — for engine C++ work"
+    echo ""
+    info "Add to your editor settings (JSON):"
+    echo '  "emmylua.ls.executablePath": "~/.local/bin/emmylua_ls",'
+    echo '  "[lua]": { "editor.defaultFormatter": "JohnnyMorganz.stylua", "editor.formatOnSave": true }'
+
+# Install git pre-commit hooks (stylua + luacheck) in BAR repo
+hooks:
+    just bar::setup-hooks
+
 # Check prerequisites and build Docker images
 check:
     #!/usr/bin/env bash

--- a/just/tei.just
+++ b/just/tei.just
@@ -1,0 +1,34 @@
+set export
+
+DEVTOOLS_DIR    := justfile_directory()
+COMPOSE_FILE    := DEVTOOLS_DIR / "docker-compose.dev.yml"
+COMPOSE         := "docker compose -f " + COMPOSE_FILE
+TEISERVER_DIR   := DEVTOOLS_DIR / "teiserver"
+
+[private]
+require-setup:
+    #!/usr/bin/env bash
+    if [ ! -d "{{TEISERVER_DIR}}" ]; then
+        echo "Error: teiserver is not cloned." >&2
+        echo "Run: just setup::init" >&2
+        exit 1
+    fi
+
+# Initialize and migrate the test database
+setup-test-db: require-setup
+    {{COMPOSE}} run --rm -e MIX_ENV=test --entrypoint "" \
+        teiserver bash -c "mix ecto.create --quiet 2>/dev/null; mix ecto.migrate --quiet"
+
+# Run teiserver mix tests
+mix *args: require-setup
+    {{COMPOSE}} run --rm -e MIX_ENV=test --entrypoint "" \
+        -v {{TEISERVER_DIR}}/test:/app/test:z \
+        teiserver mix test {{args}}
+
+alias test := mix
+
+# Drop into an interactive test shell for teiserver
+test-shell: require-setup
+    {{COMPOSE}} run --rm -e MIX_ENV=test --entrypoint "" \
+        -v {{TEISERVER_DIR}}/test:/app/test:z \
+        teiserver bash -c "echo 'Entering teiserver test shell (MIX_ENV=test). Type exit to return.' && exec bash"

--- a/just/test_check.just
+++ b/just/test_check.just
@@ -1,3 +1,0 @@
-test:
-    @echo "DEVTOOLS_DIR=$DEVTOOLS_DIR"
-    @echo "COMPOSE=$COMPOSE"


### PR DESCRIPTION
* Add bar, lua, docs, and tei just modules with recipes for linting, formatting, unit tests, integration tests, type checking, and doc generation.
* adds a recoil docs Dockerfile to support doc generation outside the github action
* Add setup::editor recipe to export distrobox binaries (emmylua_ls, clangd, stylua). This language server is very fast so should be a good solution for most people. Lets users know which plugins they should use and how to set up vscode
* Add setup::hooks for automatic pre-commit formatting
* Include engine build deps in the Containerfile, this allows me to build compile commands for the C++ during `just setup::editor`
* Include `just` in the Containerfile, allowing us to call it in there
* Readme improvements -- critically, moved just install above "quick start"

LLMs: Yes