### PR TITLE
strip off non-alphanumeric characters from teiserver healthcheck

### DIFF
--- a/just/services.just
+++ b/just/services.just
@@ -38,7 +38,7 @@ up *args:
     attempts=0
     max_attempts=120
     while [ $attempts -lt $max_attempts ]; do
-        health=$($COMPOSE ps teiserver --format '{{{{.Health}}}}' 2>/dev/null || echo "unknown")
+        health=$($COMPOSE ps teiserver --format '{{{{.Health}}}}' 2>/dev/null | tr -cd '[:alpha:]' || echo "unknown")
         case "$health" in
             healthy)
                 ok "Teiserver is healthy!"


### PR DESCRIPTION
teiserver healthcheck code returned `healthy}}` when healthy, presumably due to some silly formatting issue. This prevented just from detecting that Teiserver was in a healthy state. 

I tried changing the formatter but ran into weirdness. So I just changed it to pipe through something to only emit alphabet characters, and so now it should return `healthy` `unhealthy` `unknown` as expected.

This fixed the teiserver healthcheck and so service bring-up can continue.


Now it shows:

```
[info]  Waiting for Teiserver to become healthy (first run takes several minutes)...
  Follow progress: just services::logs teiserver

[ok]    Teiserver is healthy!

=== Services Running ===

  Teiserver Web UI    http://localhost:4000
  Teiserver HTTPS     https://localhost:8888
  Spring Protocol     localhost:8200 (TCP) / :8201 (TLS)
  PostgreSQL          localhost:5433

```