### PR TITLE
Windows phase 1 (ubuntu 24 fixes mostly)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ To set up a new distrobox standalone:
 just setup::distrobox
 ```
 
+> **Windows contributors:** run the tooling inside WSL2 while BAR itself runs natively on Windows from the normal installer. `setup::init` detects WSL and cross-compiles the engine to Windows; `link::create` links the artifacts into the Windows install dir. See [`docs/windows-wsl2.md`](docs/windows-wsl2.md) for the full walkthrough.
+
 ### Editor integration (VS Code / Cursor)
 
 Language servers and formatters live inside the distrobox. One command exports them to your host and generates `compile_commands.json` for engine C++ support:

--- a/docs/windows-1password-ssh.md
+++ b/docs/windows-1password-ssh.md
@@ -1,0 +1,114 @@
+# Windows + 1Password SSH agent → WSL
+
+Supplement to [windows-wsl2.md](./windows-wsl2.md). Covers the case where your SSH
+private key lives in 1Password (not on disk), so that `git push` from inside WSL
+authenticates against the 1Password agent running on Windows.
+
+> **Status — work in progress.** Daniel maintains this from his Windows machine.
+> If you hit a step that's missing or wrong, please file an issue.
+
+## Why this is fiddly
+
+1Password's SSH agent on Windows speaks the OpenSSH protocol over a **named pipe**
+(`\\.\pipe\openssh-ssh-agent`), not a Unix socket. WSL's OpenSSH client wants a
+Unix socket at `$SSH_AUTH_SOCK`. The bridge is `npiperelay.exe` + `socat`: socat
+listens on a Unix socket inside WSL and shuttles bytes to/from the Windows named
+pipe via npiperelay.
+
+```
+git push (WSL)
+  → ssh client (WSL)
+    → $SSH_AUTH_SOCK = /run/user/1000/ssh-agent.sock
+      → socat (WSL)
+        → npiperelay.exe (Windows, run via interop)
+          → \\.\pipe\openssh-ssh-agent (1Password)
+```
+
+## Windows side
+
+1. **Install 1Password for Windows** (the desktop app, not just the browser
+   extension). Settings → Developer → enable **"Use the SSH agent"**. Optionally
+   also enable **"Display key names when authorizing connections"** for visibility.
+
+2. **Add your SSH key to 1Password** (either generate fresh in 1Password or import
+   an existing key). Mark it as available to the SSH agent.
+
+3. **Install `npiperelay.exe`.** Easiest via [scoop](https://scoop.sh):
+
+   ```powershell
+   scoop install npiperelay
+   ```
+
+   …or grab a release binary from <https://github.com/jstarks/npiperelay/releases>
+   and put it somewhere on `PATH`. Verify:
+
+   ```powershell
+   where.exe npiperelay
+   ```
+
+4. **Disable Windows OpenSSH agent service** (so it doesn't compete with 1Password
+   on the same named pipe):
+
+   ```powershell
+   Get-Service ssh-agent | Set-Service -StartupType Disabled
+   Stop-Service ssh-agent -ErrorAction SilentlyContinue
+   ```
+
+## WSL side
+
+1. **Install `socat`** (and optionally `psmisc` for `pkill`):
+
+   ```bash
+   sudo apt install -y socat psmisc
+   ```
+
+2. **Add the bridge to your shell rc** (`~/.bashrc` or `~/.zshrc`):
+
+   ```bash
+   # 1Password SSH agent bridge: forward $SSH_AUTH_SOCK in WSL to the
+   # \\.\pipe\openssh-ssh-agent named pipe on Windows via npiperelay.
+   export SSH_AUTH_SOCK="$HOME/.ssh/agent.sock"
+
+   # Restart the bridge if no listener is on the socket.
+   if ! ss -a 2>/dev/null | grep -q "$SSH_AUTH_SOCK"; then
+       rm -f "$SSH_AUTH_SOCK"
+       ( setsid socat UNIX-LISTEN:"$SSH_AUTH_SOCK",fork \
+           EXEC:"npiperelay.exe -ei -s //./pipe/openssh-ssh-agent",nofork \
+           >/dev/null 2>&1 & )
+   fi
+   ```
+
+   Open a new shell. Verify:
+
+   ```bash
+   ssh-add -l                    # should list your 1Password-managed key(s)
+   ssh -T git@github.com         # should authenticate
+   ```
+
+## Common gotchas
+
+- **`npiperelay.exe: command not found` from WSL**: WSL needs to be able to invoke
+  Windows binaries via interop. Confirm `/etc/wsl.conf` has `interop.enabled=true`
+  (the default) and that `npiperelay.exe` is on the **Windows** `PATH`. WSL will
+  see Windows `PATH` entries appended to its own `$PATH`.
+- **Prompts not showing**: If 1Password is configured to confirm each use but no
+  prompt appears, the desktop app may have been killed by a Windows update. Open
+  it manually before pushing.
+- **`ssh-add -l` says "The agent has no identities"**: 1Password agent is running
+  but no key is marked as available. Check 1Password → the key item → **Use as
+  SSH key** is enabled.
+- **Stale socket after sleep/resume**: the rc snippet above re-spawns socat if the
+  socket has no listener, but if you see "Connection refused", `pkill socat &&
+  exec $SHELL` to force a refresh.
+
+## Why not just use Windows OpenSSH and `ssh-add` your key?
+
+That works (and is what `windows-wsl2.md` covers). 1Password buys you:
+
+- Key never written to disk in plaintext.
+- Touch-ID / Windows Hello prompt per use, instead of a passphrase typed once and
+  cached for the session.
+- Single source of truth across machines (laptop, desktop, etc.) without rsync'ing
+  `~/.ssh`.
+
+Skip this doc if those don't matter to you.

--- a/docs/windows-wsl2.md
+++ b/docs/windows-wsl2.md
@@ -1,0 +1,105 @@
+# Windows contributors (WSL2)
+
+WSL2 hosts the **tooling** (clone, build, services, linker). The **game runs natively on
+Windows** from the standard installer — WSLg is not used. Only build artifacts cross the
+WSL↔NTFS boundary.
+
+## Prerequisites
+
+1. Install [Windows Terminal](https://aka.ms/terminal) from the Microsoft Store if you
+   don't already have it. The legacy `wsl.exe` console window has poor copy/paste,
+   no tabs, and quirky font rendering — Windows Terminal is the modern replacement
+   and it tabs Linux/PowerShell/cmd in one window.
+
+2. Install WSL2 with Ubuntu 24.04:
+
+   ```powershell
+   wsl --install -d Ubuntu-24.04
+   ```
+
+3. Enable systemd inside the distro:
+
+   ```bash
+   sudo tee /etc/wsl.conf > /dev/null <<'EOF'
+   [boot]
+   systemd=true
+   EOF
+   ```
+
+   Then from PowerShell: `wsl --shutdown`, reopen the distro.
+
+4. Install the Windows-native Beyond All Reason via the normal installer. The default
+   install path (`%LOCALAPPDATA%\Programs\Beyond-All-Reason\data`) is auto-detected by
+   `just setup::init` from inside WSL; no `BAR_GAME_DIR` needed for standard installs.
+
+5. Inside the distro, install host dependencies and clone BAR-Devtools **under `~`** —
+   never under `/mnt/c`:
+
+   ```bash
+   sudo apt install -y just podman distrobox git
+   git clone https://github.com/beyond-all-reason/BAR-Devtools.git ~/BAR-Devtools
+   cd ~/BAR-Devtools
+   ```
+
+   The `/mnt/c` rule matters: WSL filesystem performance and symlink semantics both
+   degrade sharply on the NTFS drvfs mount.
+
+## Run setup
+
+```bash
+just setup::init
+```
+
+Under WSL, the engine build step cross-compiles to Windows automatically via
+`docker-build-v2` (mingw-w64). Output lands at `RecoilEngine/build-amd64-windows/install/`.
+The link step points the Windows BAR install at that artifact.
+
+If you want to re-link later:
+
+```bash
+just link::status               # see current symlinks
+just link::create engine        # (re)link engine build to Windows install
+just link::create chobby
+just link::create bar
+```
+
+## Launching the game
+
+Launch `Beyond-All-Reason.exe` natively from Windows as usual. It picks up the symlinked
+dev engine and lua from the Windows install dir.
+
+## Known risk — NTFS symlinks
+
+Symlinks created from WSL2 into `/mnt/c/...` show up as NTFS junctions that Windows
+usually follows, but this is the one part of the flow that hasn't been proven on every
+Windows configuration. If `Beyond-All-Reason.exe` doesn't see your dev engine or lua
+changes, the most likely cause is a symlink that Windows silently isn't following.
+
+## VS Code
+
+Install the [WSL extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl),
+open `~/BAR-Devtools` in WSL from the Command Palette (`WSL: Open Folder in WSL...`),
+and everything works as if you were on Linux.
+
+## SSH agent forwarding
+
+For GitHub push access from inside WSL:
+
+```powershell
+# In your Windows PowerShell profile (~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1):
+Get-Service ssh-agent | Set-Service -StartupType Automatic
+Start-Service ssh-agent
+ssh-add ~\.ssh\id_ed25519   # or your key path
+```
+
+```bash
+# In WSL ~/.bashrc or ~/.zshrc:
+eval "$(ssh-agent -s)" > /dev/null 2>&1
+# OR use socat to forward the Windows agent — see https://stuartleeks.com/posts/wsl-ssh-key-forward-to-windows/
+```
+
+Verify with `ssh -T git@github.com` from WSL before running `setup::init`.
+
+If you keep your SSH key in 1Password (or Bitwarden) instead of on disk, see
+[windows-1password-ssh.md](./windows-1password-ssh.md) for the agent passthrough
+into WSL.

--- a/scripts/repos.sh
+++ b/scripts/repos.sh
@@ -81,6 +81,12 @@ clone_or_update_repo() {
     fi
     info "  ${dir}: fetching latest..."
     git -C "$target" fetch origin --quiet 2>/dev/null || warn "  ${dir}: fetch failed (offline?)"
+    # Sync submodules — needed at minimum for RecoilEngine (rmlui, rapidjson,
+    # spring-restbase, etc). Existing checkouts predating this addition won't
+    # have submodules initialized; --init handles them, --recursive walks
+    # nested submodules. Quiet on success; failures (offline, auth) just warn.
+    git -C "$target" submodule update --init --recursive --quiet 2>/dev/null \
+      || warn "  ${dir}: submodule sync failed (offline or auth?)"
     local current_branch
     current_branch="$(git -C "$target" branch --show-current 2>/dev/null)"
     if [ -n "$current_branch" ] && [ "$current_branch" != "$branch" ]; then
@@ -88,7 +94,7 @@ clone_or_update_repo() {
     fi
   else
     info "  ${dir}: cloning ${url} (branch: ${branch})..."
-    git clone --branch "$branch" "$url" "$target" 2>&1 | sed 's/^/    /'
+    git clone --recurse-submodules --branch "$branch" "$url" "$target" 2>&1 | sed 's/^/    /'
   fi
 }
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -15,6 +15,10 @@ detect_distro() {
   fi
 }
 
+is_wsl() {
+  [ -n "${WSL_DISTRO_NAME:-}" ] || [ -f /proc/sys/fs/binfmt_misc/WSLInterop ]
+}
+
 pkg_install_cmd() {
   case "$(detect_distro)" in
     arch)   echo "sudo pacman -S --needed" ;;
@@ -340,14 +344,15 @@ cmd_init() {
     echo ""
     read -rp "Build engine from source? [y/N] " build_engine
     if [[ "$build_engine" =~ ^[Yy]$ ]]; then
-      local engine_arch
+      local engine_arch engine_os="linux"
       case "$(uname -m)" in
         x86_64)       engine_arch="amd64" ;;
         aarch64|arm64) engine_arch="arm64" ;;
         *)            engine_arch="amd64" ;;
       esac
-      info "Building Recoil engine (${engine_arch}-linux, this may take a while)..."
-      bash "$DEVTOOLS_DIR/RecoilEngine/docker-build-v2/build.sh" --arch "$engine_arch" linux
+      is_wsl && engine_os="windows"
+      info "Building Recoil engine (${engine_arch}-${engine_os}, this may take a while)..."
+      bash "$DEVTOOLS_DIR/RecoilEngine/docker-build-v2/build.sh" --arch "$engine_arch" "$engine_os"
     fi
     echo ""
   else
@@ -455,6 +460,17 @@ detect_game_dir() {
     echo "$candidate"
     return 0
   fi
+  if is_wsl && command -v wslpath &>/dev/null && command -v cmd.exe &>/dev/null; then
+    local win_userprofile
+    win_userprofile="$(cmd.exe /c 'echo %USERPROFILE%' 2>/dev/null | tr -d '\r\n')"
+    if [ -n "$win_userprofile" ]; then
+      candidate="$(wslpath "$win_userprofile")/AppData/Local/Programs/Beyond-All-Reason/data"
+      if [ -d "$candidate" ]; then
+        echo "$candidate"
+        return 0
+      fi
+    fi
+  fi
   return 1
 }
 
@@ -503,7 +519,14 @@ cmd_link() {
   local source_path link_path
   case "$target" in
     engine)
-      source_path="$DEVTOOLS_DIR/RecoilEngine/build-linux/install"
+      local engine_arch engine_os="linux"
+      case "$(uname -m)" in
+        x86_64)        engine_arch="amd64" ;;
+        aarch64|arm64) engine_arch="arm64" ;;
+        *)             engine_arch="amd64" ;;
+      esac
+      is_wsl && engine_os="windows"
+      source_path="$DEVTOOLS_DIR/RecoilEngine/build-${engine_arch}-${engine_os}/install"
       link_path="$game_dir/engine/local-build"
       ;;
     chobby)
@@ -524,7 +547,11 @@ cmd_link() {
   if [ ! -e "$source_path" ] && [ ! -L "$source_path" ]; then
     err "Source not found: $source_path"
     if [ "$target" = "engine" ]; then
-      echo "  Build the engine first: just engine::build linux"
+      if is_wsl; then
+        echo "  Build the engine first: just engine::build windows"
+      else
+        echo "  Build the engine first: just engine::build linux"
+      fi
     else
       echo "  Clone the repo first: just repos::clone extra"
     fi


### PR DESCRIPTION
Fixing linking and other random things I encounter. Adding instructions as I go.

* fixed the README to tell debian users to run a `just`-recommended custom script to install the latest
* distrobox and docker had similar issues with 2017 package pinning from apt in ubuntu, used a custom script and switching out the apt package, respectively
* wsl setup prep
```
=== WSL2 environment prep ===

[sudo] password for daniel:
[ok]    WSL2 environment ready (systemd active, / is a shared mount)

[step]  1/6  Checking & installing dependencies

[ok]    Core dependencies (git, docker) already installed.
```
* updated the feature selection to be less tei-server focused. With windows users coming in this repo is just as likely to be BAR oriented. If you pick Recoil it automatically compiles the engine for you before linking.

<img width="1047" height="489" alt="image" src="https://github.com/user-attachments/assets/7fcdb2ac-446d-4fd9-bf61-928a57950299" />

Along with that, eliminated "extra" and "core" in favor of specific tags, for example
```
Beyond-All-Reason    https://github.com/beyond-all-reason/Beyond-All-Reason.git    master    bar
bar-lobby            https://github.com/beyond-all-reason/bar-lobby.git             master    bar,chobby
```
* adds some convenience directives to `repos.local.conf`

   - `@local_root <path>`     for every repo, use `<path>/<dir>` as the local checkout
                (auto-cloned and symlinked into the workspace).
                Per-row local_path columns still win.

    - `@protocol ssh|https`    rewrite github.com URLs between SSH and HTTPS.
                Use 'ssh' if HTTPS is slow or for push-by-default.

Example minimal
```repos.local.conf
@local_root ~/code
@protocol ssh
```
