### PR TITLE
dev image: install gawk in dev.Containerfile

### DIFF
--- a/docker/dev.Containerfile
+++ b/docker/dev.Containerfile
@@ -10,6 +10,7 @@ RUN dnf install -y --setopt=install_weak_deps=False \
         clang-tools-extra cmake \
         just \
         gcc gcc-c++ make git curl jq unzip binutils \
+        gawk \
         SDL2-devel DevIL-devel glew-devel openal-soft-devel \
         libvorbis-devel freetype-devel fontconfig-devel \
         libunwind-devel libcurl-devel jsoncpp-devel minizip-devel \


### PR DESCRIPTION
## Summary
Adds gawk to the dev container so scripts that require GNU awk extensions (versus busybox awk) work inside the distrobox without surprise. Containerfile-only change.

## Test plan
- [x] \`just setup::distrobox\` rebuilds the image without errors
- [x] \`distrobox enter \$DEVTOOLS_DISTROBOX -- gawk --version\` works