### PR TITLE
doctor: handle local teiserver checkout in scripts/doctor.sh

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -157,9 +157,10 @@ check_doctor_images() {
     return
   fi
 
-  local project_name
+  local project_name teiserver_image
   project_name="$(basename "$DEVTOOLS_DIR" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]_-')"
-  if docker compose -f "$DEVTOOLS_DIR/docker-compose.dev.yml" images teiserver 2>/dev/null | grep -i teiserver | grep -q .; then
+  teiserver_image="${project_name}-teiserver:latest"
+  if docker image inspect "$teiserver_image" &>/dev/null; then
     _pass "Teiserver image built"
   elif [ ! -d "$DEVTOOLS_DIR/teiserver" ]; then
     _fail "Teiserver image not built (teiserver repo not cloned)"


### PR DESCRIPTION
## Summary
Small \`scripts/doctor.sh\` tweak so the doctor recipe works correctly when teiserver is configured as a local checkout via \`repos.local.conf\` rather than cloned. Doctor-script-only change.

## Test plan
- [x] \`just doctor\` reports the teiserver image as built when it actually is, regardless of clone-vs-symlink