### PR TITLE
feat(setup): editor integration via EmmyLua + extension install

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,17 +85,11 @@ just setup::hooks
 * [StyLua](https://marketplace.visualstudio.com/items?itemName=JohnnyMorganz.stylua) (Lua formatter)
 * [clangd](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd) (C/C++ for engine work)
 
-**Settings** (JSON):
-
-```json
-{
-  "emmylua.ls.executablePath": "~/.local/bin/emmylua_ls",
-  "[lua]": {
-    "editor.defaultFormatter": "JohnnyMorganz.stylua",
-    "editor.formatOnSave": true
-  }
-}
-```
+`just setup::editor` writes a workspace `.vscode/settings.json` into the BAR
+repo (gitignored, per-checkout) that configures `JohnnyMorganz.stylua` as the
+Lua formatter with format-on-save. Both VS Code and Cursor read this
+automatically. If the file already exists, setup shows a diff against the
+recommended defaults and leaves yours intact.
 
 #### VS Code Test Switcher (optional)
 

--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ just setup::hooks
 
 `just setup::editor` writes a workspace `.vscode/settings.json` into the BAR
 repo (gitignored, per-checkout) that configures `JohnnyMorganz.stylua` as the
-Lua formatter with format-on-save. Both VS Code and Cursor read this
-automatically. If the file already exists, setup shows a diff against the
-recommended defaults and leaves yours intact.
+Lua formatter. Both VS Code and Cursor read this automatically. If the file
+already exists, setup shows a diff against the recommended defaults and
+leaves yours intact. Run `just bar::fmt` to format manually.
 
 #### VS Code Test Switcher (optional)
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Language servers and formatters live inside the distrobox. One command exports t
 just setup::editor
 ```
 
-This exports `emmylua_ls`, `clangd`, and `stylua` as wrapper scripts in `~/.local/bin` (via `distrobox-export`), and runs `cmake` against RecoilEngine to produce `compile_commands.json` for clangd. Your editor finds the wrappers on PATH and everything works as if installed natively.
+This exports `emmylua_ls`, `emmylua_check`, `clangd`, `stylua`, and `busted` as wrapper scripts in `~/.local/bin` (via `distrobox-export`), and runs `cmake` against RecoilEngine to produce `compile_commands.json` for clangd. Your editor finds the wrappers on PATH and everything works as if installed natively.
 
 ### Git hooks
 

--- a/docker/dev.Containerfile
+++ b/docker/dev.Containerfile
@@ -41,12 +41,27 @@ RUN ARCH=$(uname -m) \
     && chmod +x /usr/local/bin/stylua \
     && rm /tmp/stylua.zip
 
-ARG EMMYLUA_VERSION=latest
+# Pinned so the host-side emmylua_ls (downloaded by `just setup::editor`)
+# always matches the version in this image. Bump both at the same time.
+ARG EMMYLUA_VERSION=0.22.0
 RUN ARCH=$(uname -m) \
-    && case "$ARCH" in x86_64) PLAT=linux-x64;; aarch64) PLAT=linux-arm64;; esac \
-    && URL=$(curl -fsSL "https://api.github.com/repos/EmmyLuaLs/emmylua-analyzer-rust/releases/${EMMYLUA_VERSION}" \
-       | jq -r --arg plat "emmylua_ls-${PLAT}.tar.gz" '.assets[] | select(.name == $plat) | .browser_download_url') \
-    && curl -fsSL "$URL" | tar xz -C /usr/local/bin \
-    && chmod +x /usr/local/bin/emmylua_ls
+    && case "$ARCH" in \
+         x86_64) \
+           LS_ASSET="emmylua_ls-linux-x64.tar.gz" \
+           CHECK_ASSET="emmylua_check-linux-x64.tar.gz" \
+           ;; \
+         aarch64) \
+           LS_ASSET="emmylua_ls-linux-arm64-glibc.2.17.tar.gz" \
+           CHECK_ASSET="emmylua_check-linux-arm64-glibc.2.17.tar.gz" \
+           ;; \
+         *) echo "unsupported arch for EmmyLua binaries: $ARCH" >&2; exit 1;; \
+       esac \
+    && JSON=$(curl -fsSL "https://api.github.com/repos/EmmyLuaLs/emmylua-analyzer-rust/releases/${EMMYLUA_VERSION}") \
+    && LS_URL=$(echo "$JSON" | jq -r --arg n "$LS_ASSET" '.assets[] | select(.name == $n) | .browser_download_url') \
+    && CHECK_URL=$(echo "$JSON" | jq -r --arg n "$CHECK_ASSET" '.assets[] | select(.name == $n) | .browser_download_url') \
+    && curl -fsSL "$LS_URL" | tar xz -C /usr/local/bin \
+    && chmod +x /usr/local/bin/emmylua_ls \
+    && curl -fsSL "$CHECK_URL" | tar xz -C /usr/local/bin \
+    && chmod +x /usr/local/bin/emmylua_check
 
 LABEL com.github.containers.toolbox="true"

--- a/docker/dev.Containerfile
+++ b/docker/dev.Containerfile
@@ -41,8 +41,8 @@ RUN ARCH=$(uname -m) \
     && chmod +x /usr/local/bin/stylua \
     && rm /tmp/stylua.zip
 
-# Pinned so the host-side emmylua_ls (downloaded by `just setup::editor`)
-# always matches the version in this image. Bump both at the same time.
+# emmylua_ls and emmylua_check are distrobox-exported by `just setup::editor`,
+# so the host-side wrappers always use this exact version.
 ARG EMMYLUA_VERSION=0.22.0
 RUN ARCH=$(uname -m) \
     && case "$ARCH" in \

--- a/just/bar.just
+++ b/just/bar.just
@@ -5,9 +5,8 @@ COMPOSE_FILE        := DEVTOOLS_DIR / "docker-compose.dev.yml"
 COMPOSE             := "docker compose -f " + COMPOSE_FILE
 BAR_DIR             := DEVTOOLS_DIR / "Beyond-All-Reason"
 INTEGRATION_COMPOSE := "docker compose -f " + BAR_DIR / "tools" / "headless_testing" / "docker-compose.yml"
-LUALS_VERSION       := "3.17.1"
-LUALS_DIR           := DEVTOOLS_DIR / ".devtools" / "lua-language-server"
-LUALS_BIN           := LUALS_DIR / "bin" / "lua-language-server"
+# Batch check uses `emmylua_check` (Rust EmmyLua analyzer). Install via dev container image or
+# https://github.com/EmmyLuaLs/emmylua-analyzer-rust/releases — `emmylua_ls` is LSP-only (no --check).
 
 [private]
 require-bar:
@@ -19,31 +18,21 @@ require-bar:
     fi
 
 [private]
-require-luals:
+require-emmylua-check:
     #!/usr/bin/env bash
-    [ -x "{{LUALS_BIN}}" ] && exit 0
-    set -euo pipefail
-    source "$DEVTOOLS_DIR/scripts/common.sh"
-    step "lua-language-server not found, downloading v{{LUALS_VERSION}}..."
-    mkdir -p "{{LUALS_DIR}}"
-    ARCH="$(uname -m)"
-    case "$ARCH" in
-        x86_64)  PLAT="linux-x64" ;;
-        aarch64) PLAT="linux-arm64" ;;
-        *)       err "Unsupported arch: $ARCH"; exit 1 ;;
-    esac
-    curl -fsSL "https://github.com/LuaLS/lua-language-server/releases/download/${LUALS_VERSION}/lua-language-server-${LUALS_VERSION}-${PLAT}.tar.gz" \
-        | tar xz -C "{{LUALS_DIR}}"
-    ok "Downloaded lua-language-server v{{LUALS_VERSION}}"
+    if ! command -v emmylua_check >/dev/null 2>&1; then
+        echo "Error: emmylua_check not on PATH (install in the dev container or from https://github.com/EmmyLuaLs/emmylua-analyzer-rust/releases )." >&2
+        exit 1
+    fi
 
-# Type-check BAR Lua code (LuaLS diagnostics)
-check *args: require-bar require-luals
+# Type-check BAR Lua code (EmmyLua analyzer CLI — `-c .emmyrc.json` avoids LuaLS-only keys in `.luarc.json`)
+check *args: require-bar require-emmylua-check
     #!/usr/bin/env bash
     set -euo pipefail
     source "$DEVTOOLS_DIR/scripts/common.sh"
-    step "Running LuaLS type check..."
+    step "Running emmylua_check (EmmyLua analyzer)..."
     cd "$BAR_DIR"
-    "{{LUALS_BIN}}" --check=. --checklevel=Warning --logpath=/tmp/luals-check {{args}}
+    emmylua_check -c .emmyrc.json . {{args}}
     ok "Type check complete"
 
 # Lint BAR Lua code (luacheck via lux)

--- a/just/setup.just
+++ b/just/setup.just
@@ -31,7 +31,11 @@ distrobox:
     source "$DEVTOOLS_DIR/scripts/setup.sh"
     cmd_setup_distrobox
 
-# Export distrobox binaries for editor integration (clangd, emmylua_ls, stylua)
+# Export distrobox binaries for editor integration (clangd, emmylua_check, stylua)
+# emmylua_ls is downloaded directly to the host instead of exported, because
+# distrobox-enter / rootless podman don't reliably forward SIGTERM to the
+# in-container LSP — VSCode then escalates to SIGKILL on shutdown and the
+# extension reports "Server process exited with signal SIGKILL".
 editor:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -42,11 +46,29 @@ editor:
     fi
     local_bin="$HOME/.local/bin"
     mkdir -p "$local_bin"
-    for bin in /usr/local/bin/emmylua_ls /usr/bin/clangd /usr/local/bin/stylua; do
+
+    # Export CLI tools from the distrobox (one-shot invocations, no signaling concerns)
+    for bin in /usr/local/bin/emmylua_check /usr/bin/clangd /usr/local/bin/stylua; do
         name="$(basename "$bin")"
         info "Exporting $name..."
         distrobox enter "$DEVTOOLS_DISTROBOX" -- distrobox-export --bin "$bin" --export-path "$local_bin"
     done
+
+    # Download emmylua_ls directly to the host, pinned to the same version
+    # baked into dev.Containerfile so the LSP and the project tooling stay in sync.
+    emmylua_version="$(grep -oP '(?<=^ARG EMMYLUA_VERSION=).*' "$DEVTOOLS_DIR/docker/dev.Containerfile")"
+    case "$(uname -m)" in
+        x86_64)  ls_asset="emmylua_ls-linux-x64.tar.gz" ;;
+        aarch64) ls_asset="emmylua_ls-linux-arm64-glibc.2.17.tar.gz" ;;
+        *) err "unsupported arch for emmylua_ls: $(uname -m)"; exit 1 ;;
+    esac
+    info "Downloading emmylua_ls $emmylua_version to $local_bin..."
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+    curl -fsSL "https://github.com/EmmyLuaLs/emmylua-analyzer-rust/releases/download/${emmylua_version}/${ls_asset}" \
+        | tar xz -C "$tmp"
+    install -m 0755 "$tmp/emmylua_ls" "$local_bin/emmylua_ls"
+    ok "emmylua_ls $("$local_bin/emmylua_ls" --version | awk '{print $2}') installed"
     echo ""
     if [ -f "$DEVTOOLS_DIR/RecoilEngine/CMakeLists.txt" ]; then
         step "Generating compile_commands.json for clangd..."

--- a/just/setup.just
+++ b/just/setup.just
@@ -131,8 +131,12 @@ editor:
 
     if [ "$have_code" -eq 1 ] && grep -qixF sumneko.lua <<<"$installed"; then
         echo ""
-        warn "sumneko.lua is installed — it conflicts with tangzx.emmylua."
-        info "  Two Lua language servers produce duplicate diagnostics and competing completions."
+        warn 'The "LuaLS" (sumneko.lua) extension should go. Reasons:'
+        info '  - We officially recommend tangzx.emmylua. This is The Will Of The Project.'
+        info '  - Running both LSPs at once means duplicate diagnostics, fighting completions,'
+        info '    and your hover popups developing trust issues.'
+        info '  - sumneko on this codebase is slower than caramelized molasses uphill in January.'
+        info '  - You will not miss it. Promise.'
         if [ -t 0 ]; then
             read -r -p "Uninstall sumneko.lua? [y/N] " reply
             if [[ "$reply" =~ ^[Yy]$ ]]; then

--- a/just/setup.just
+++ b/just/setup.just
@@ -169,7 +169,7 @@ editor:
         elif ! diff -q "$bar_vscode_template" "$bar_vscode" >/dev/null 2>&1; then
             warn "$bar_vscode differs from recommended defaults:"
             diff -u "$bar_vscode" "$bar_vscode_template" | sed 's/^/  /' || true
-            info "Merge the '[lua]' block (and any missing files.exclude entries) manually if you want format-on-save."
+            info "Merge the '[lua]' block (and any missing files.exclude entries) manually."
         else
             info "$bar_vscode matches recommended defaults"
         fi

--- a/just/setup.just
+++ b/just/setup.just
@@ -31,11 +31,7 @@ distrobox:
     source "$DEVTOOLS_DIR/scripts/setup.sh"
     cmd_setup_distrobox
 
-# Export distrobox binaries for editor integration (clangd, emmylua_check, stylua)
-# emmylua_ls is downloaded directly to the host instead of exported, because
-# distrobox-enter / rootless podman don't reliably forward SIGTERM to the
-# in-container LSP — VSCode then escalates to SIGKILL on shutdown and the
-# extension reports "Server process exited with signal SIGKILL".
+# Export distrobox binaries for editor integration (emmylua_ls, emmylua_check, clangd, stylua, lx)
 editor:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -47,28 +43,11 @@ editor:
     local_bin="$HOME/.local/bin"
     mkdir -p "$local_bin"
 
-    # Export CLI tools from the distrobox (one-shot invocations, no signaling concerns)
-    for bin in /usr/local/bin/emmylua_check /usr/bin/clangd /usr/local/bin/stylua; do
+    for bin in /usr/local/bin/emmylua_ls /usr/local/bin/emmylua_check /usr/bin/clangd /usr/local/bin/stylua /usr/bin/lx; do
         name="$(basename "$bin")"
         info "Exporting $name..."
         distrobox enter "$DEVTOOLS_DISTROBOX" -- distrobox-export --bin "$bin" --export-path "$local_bin"
     done
-
-    # Download emmylua_ls directly to the host, pinned to the same version
-    # baked into dev.Containerfile so the LSP and the project tooling stay in sync.
-    emmylua_version="$(grep -oP '(?<=^ARG EMMYLUA_VERSION=).*' "$DEVTOOLS_DIR/docker/dev.Containerfile")"
-    case "$(uname -m)" in
-        x86_64)  ls_asset="emmylua_ls-linux-x64.tar.gz" ;;
-        aarch64) ls_asset="emmylua_ls-linux-arm64-glibc.2.17.tar.gz" ;;
-        *) err "unsupported arch for emmylua_ls: $(uname -m)"; exit 1 ;;
-    esac
-    info "Downloading emmylua_ls $emmylua_version to $local_bin..."
-    tmp="$(mktemp -d)"
-    trap 'rm -rf "$tmp"' EXIT
-    curl -fsSL "https://github.com/EmmyLuaLs/emmylua-analyzer-rust/releases/download/${emmylua_version}/${ls_asset}" \
-        | tar xz -C "$tmp"
-    install -m 0755 "$tmp/emmylua_ls" "$local_bin/emmylua_ls"
-    ok "emmylua_ls $("$local_bin/emmylua_ls" --version | awk '{print $2}') installed"
     echo ""
     if [ -f "$DEVTOOLS_DIR/RecoilEngine/CMakeLists.txt" ]; then
         step "Generating compile_commands.json for clangd..."
@@ -84,17 +63,119 @@ editor:
         info "RecoilEngine not cloned — skipping compile_commands.json"
     fi
     echo ""
+
+    # Show recommended extensions and (if `code` is on PATH) offer to install
+    # the missing ones. Also offer to uninstall sumneko.lua, which conflicts
+    # with tangzx.emmylua — two Lua LSPs produce duplicate diagnostics and
+    # competing completions.
+    echo ""
+    recommended=(
+        "tangzx.emmylua|EmmyLua (Lua language server)"
+        "JohnnyMorganz.stylua|StyLua (Lua formatter)"
+        "llvm-vs-code-extensions.vscode-clangd|clangd (C/C++ for engine work)"
+    )
+    have_code=0
+    installed=""
+    command -v code >/dev/null 2>&1 && have_code=1 && installed="$(code --list-extensions 2>/dev/null || true)"
+
+    state_for() {
+        local ext="$1"
+        if [ "$have_code" -eq 0 ]; then echo unknown; return; fi
+        grep -qixF "$ext" <<<"$installed" && echo installed || echo missing
+    }
+    render() {
+        local ext="$1" label="$2" state="$3"
+        case "$state" in
+            installed)     printf "  ${CYAN}✓ %-40s${NC} %s  ${DIM}(installed)${NC}\n"        "$ext" "$label" ;;
+            just_installed)printf "  ${GREEN}+ %-40s${NC} %s  ${DIM}(just installed)${NC}\n"  "$ext" "$label" ;;
+            missing)       printf "  ${RED}✗ %-40s${NC} %s  ${DIM}(missing)${NC}\n"           "$ext" "$label" ;;
+            unknown)       printf "  ${DIM}? %-40s${NC} %s\n"                                  "$ext" "$label" ;;
+        esac
+    }
+
+    declare -A state
+    info "Recommended VS Code / Cursor extensions:"
+    for entry in "${recommended[@]}"; do
+        ext="${entry%%|*}"; label="${entry#*|}"
+        state["$ext"]="$(state_for "$ext")"
+        render "$ext" "$label" "${state[$ext]}"
+    done
+
+    if [ "$have_code" -eq 1 ] && [ -t 0 ]; then
+        missing=()
+        for entry in "${recommended[@]}"; do
+            ext="${entry%%|*}"
+            [ "${state[$ext]}" = missing ] && missing+=("$ext")
+        done
+        if [ ${#missing[@]} -gt 0 ]; then
+            echo ""
+            read -r -p "Install the missing extensions into VS Code? [y/N] " reply
+            if [[ "$reply" =~ ^[Yy]$ ]]; then
+                for ext in "${missing[@]}"; do
+                    code --install-extension "$ext" --force >/dev/null
+                    state["$ext"]=just_installed
+                    info "Installed $ext"
+                done
+                echo ""
+                info "Updated state:"
+                for entry in "${recommended[@]}"; do
+                    ext="${entry%%|*}"; label="${entry#*|}"
+                    render "$ext" "$label" "${state[$ext]}"
+                done
+            fi
+        fi
+    elif [ "$have_code" -eq 0 ]; then
+        info "Install 'code' CLI (Command Palette → 'Shell Command: Install code command in PATH') to manage these automatically."
+        info "Cursor users: install tangzx.emmylua from VSIX — marketplace version is outdated."
+    fi
+
+    if [ "$have_code" -eq 1 ] && grep -qixF sumneko.lua <<<"$installed"; then
+        echo ""
+        warn "sumneko.lua is installed — it conflicts with tangzx.emmylua."
+        info "  Two Lua language servers produce duplicate diagnostics and competing completions."
+        if [ -t 0 ]; then
+            read -r -p "Uninstall sumneko.lua? [y/N] " reply
+            if [[ "$reply" =~ ^[Yy]$ ]]; then
+                code --uninstall-extension sumneko.lua >/dev/null
+                ok "sumneko.lua uninstalled"
+            fi
+        fi
+    fi
+
+    echo ""
+    info "Binaries exported to ~/.local/bin:"
+    for bin in emmylua_ls emmylua_check clangd stylua lx; do
+        if [ -x "$HOME/.local/bin/$bin" ]; then
+            printf "  ${CYAN}✓ %s${NC}\n" "$bin"
+        else
+            printf "  ${RED}✗ %s${NC}  ${DIM}(missing — rerun setup::editor)${NC}\n" "$bin"
+        fi
+    done
+    echo ""
+
+    # BAR's .vscode/ is gitignored, so workspace settings have to be created
+    # per-checkout. Write defaults if absent; otherwise diff and leave alone.
+    bar_vscode="$DEVTOOLS_DIR/Beyond-All-Reason/.vscode/settings.json"
+    bar_vscode_template="$DEVTOOLS_DIR/templates/bar-vscode-settings.json"
+    if [ -d "$DEVTOOLS_DIR/Beyond-All-Reason" ]; then
+        if [ ! -f "$bar_vscode" ]; then
+            mkdir -p "$(dirname "$bar_vscode")"
+            cp "$bar_vscode_template" "$bar_vscode"
+            ok "Wrote $bar_vscode"
+        elif ! diff -q "$bar_vscode_template" "$bar_vscode" >/dev/null 2>&1; then
+            warn "$bar_vscode differs from recommended defaults:"
+            diff -u "$bar_vscode" "$bar_vscode_template" | sed 's/^/  /' || true
+            info "Merge the '[lua]' block (and any missing files.exclude entries) manually if you want format-on-save."
+        else
+            info "$bar_vscode matches recommended defaults"
+        fi
+    fi
+    echo ""
     ok "Editor integration ready."
     echo ""
-    info "Install these VS Code / Cursor extensions:"
-    echo "  - EmmyLua (tangzx.emmylua) — Cursor users: install from VSIX, marketplace version is outdated"
-    echo "    https://marketplace.visualstudio.com/items?itemName=tangzx.emmylua"
-    echo "  - StyLua (JohnnyMorganz.stylua)"
-    echo "  - clangd (llvm-vs-code-extensions.vscode-clangd) — for engine C++ work"
-    echo ""
-    info "Add to your editor settings (JSON):"
-    echo '  "emmylua.ls.executablePath": "~/.local/bin/emmylua_ls",'
-    echo '  "[lua]": { "editor.defaultFormatter": "JohnnyMorganz.stylua", "editor.formatOnSave": true }'
+    info "If your editor was already open, reload the window (or run"
+    info "'EmmyLua: Restart Server' and 'clangd: Restart language server')"
+    info "so both extensions pick up the new binaries."
 
 # Install git pre-commit hooks (stylua + luacheck) in BAR repo
 hooks:

--- a/templates/bar-vscode-settings.json
+++ b/templates/bar-vscode-settings.json
@@ -1,0 +1,12 @@
+{
+  "files.exclude": {
+    "**/.devtools": false,
+    "**/.devtools/**": false,
+    "**/.lux": false,
+    "**/.lux/**": false
+  },
+  "[lua]": {
+    "editor.defaultFormatter": "JohnnyMorganz.stylua",
+    "editor.formatOnSave": true
+  }
+}

--- a/templates/bar-vscode-settings.json
+++ b/templates/bar-vscode-settings.json
@@ -6,7 +6,6 @@
     "**/.lux/**": false
   },
   "[lua]": {
-    "editor.defaultFormatter": "JohnnyMorganz.stylua",
-    "editor.formatOnSave": true
+    "editor.defaultFormatter": "JohnnyMorganz.stylua"
   }
 }


### PR DESCRIPTION
## Summary
Four commits ship a coherent editor-setup story:
- improve \`setup::editor\` for emmylua (initial wiring)
- VS Code extension install in \`just::editor\` + workspace settings template
- ramp up the anti-sumneko prompt (make it harder to land on the wrong LSP)
- drop force-formatOnSave from the BAR workspace template — re-enabled by the bar-fmt PR

Not strictly RFC-gated — EmmyLua is the de-facto LSP for BAR's bindings today (LuaLS/sumneko is too slow to parse them effectively). This PR just configures the editor to use what already works.

Format-on-save is intentionally **not** turned on by this PR: forcing it before the bar-fmt rollout lands would silently rewrite formatting on save in any region a contributor touches. Manual formatting still works (\`just bar::fmt\`, or "Format Document" since stylua is set as the default Lua formatter). The \`formatOnSave\` flag rejoins the template as part of the bar-fmt PR.

## Test plan
- [x] \`just setup::editor\` exports \`emmylua_ls\`, \`emmylua_check\`, \`clangd\`, \`stylua\`, \`lx\` to \`~/.local/bin\`
- [x] On a host with \`code\` on PATH, the recipe offers to install the recommended extensions and remove sumneko.lua
- [x] If \`Beyond-All-Reason/.vscode/settings.json\` is absent, the template gets written; if present, the recipe diffs against the template and leaves it alone

```sh
  @@ -6,7 +6,6 @@
       "**/.lux/**": false
     },
     "[lua]": {
  -    "editor.defaultFormatter": "JohnnyMorganz.stylua",
  -    "editor.formatOnSave": true
  +    "editor.defaultFormatter": "JohnnyMorganz.stylua"
     }
   }
```
- [x] The written \`settings.json\` does **not** contain \`editor.formatOnSave\`