### PR TITLE
Lua check

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -84,6 +84,12 @@ services:
       dockerfile: ../../../docker/recoil-docs.Dockerfile
     platform: linux/amd64
     profiles: ["docs"]
+    # Match the host UID/GID so files the extractor writes into the
+    # /recoil mount (e.g. rts/Lua/library/generated/) are host-owned.
+    # Without this the container runs as root, leaves root-owned files
+    # in the host's RecoilEngine checkout, and host-side cleanup
+    # (git clean, rm, just lua::reset) fails with EACCES.
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"
     volumes:
       - ./RecoilEngine:/recoil:z
     working_dir: /recoil/doc/site

--- a/docker/recoil-docs.Dockerfile
+++ b/docker/recoil-docs.Dockerfile
@@ -20,7 +20,36 @@ RUN mise trust . && \
     mise use -g node@lts rust@stable go@latest && \
     MISE_ENV=ci mise install
 
+# lua-language-server is task-scoped (used by lua_check) and isn't installed
+# by `mise install` since mise.ci.toml doesn't list it. Pre-install it so
+# runtime users (which can't write to the root-owned data dir) don't trip
+# trying to install it on first run.
+ARG LUA_LANGUAGE_SERVER_VERSION=3.15.0
+RUN MISE_ENV=ci mise use -g lua-language-server@${LUA_LANGUAGE_SERVER_VERSION}
+
 COPY go.mod go.sum hugo.toml ./
 RUN MISE_ENV=ci mise exec -- hugo mod get
+
+# Make the mise install/state readable+executable by any uid so this image
+# can run as the host user (compose passes `user: ${UID}:${GID}` so files
+# the extractor writes to the mounted /recoil tree end up host-owned, not
+# root-owned — otherwise host-side `git clean`/`rm` of generated/ fails).
+#
+# lua-language-server generates per-locale/version meta files inside its
+# install dir on first run (e.g. `meta/Lua 5.4 en-us utf8/`); make that
+# subtree world-writable so any uid can populate it. Everything else
+# stays read-only.
+RUN chmod -R a+rX /root /root/.local && \
+    chmod -R a+rwX /root/.local/share/mise/installs/lua-language-server
+
+# Mise looks at $XDG_DATA_HOME/mise (or $HOME/.local/share/mise) for installed
+# tools. Pin both so a non-root runtime user picks up the root-installed
+# tools. HOME=/tmp keeps mise's runtime cache writable for any uid.
+# MISE_TRUSTED_CONFIG_PATHS short-circuits mise's per-user trust check so the
+# root-side `mise trust .` from build time carries over to the runtime user.
+ENV HOME=/tmp \
+    MISE_DATA_DIR=/root/.local/share/mise \
+    MISE_GLOBAL_CONFIG_FILE=/root/.config/mise/config.toml \
+    MISE_TRUSTED_CONFIG_PATHS=/recoil/doc/site/mise.toml:/recoil/doc/site/mise.ci.toml:/root/.config/mise/config.toml
 
 ENTRYPOINT ["mise", "run"]

--- a/just/lua.just
+++ b/just/lua.just
@@ -4,6 +4,11 @@ DEVTOOLS_DIR := justfile_directory()
 RECOIL_DIR   := DEVTOOLS_DIR / "RecoilEngine"
 BAR_DIR      := DEVTOOLS_DIR / "Beyond-All-Reason"
 LDE_DIR      := DEVTOOLS_DIR / "lua-doc-extractor"
+COMPOSE_FILE := DEVTOOLS_DIR / "docker-compose.dev.yml"
+COMPOSE      := "docker compose -f " + COMPOSE_FILE
+
+# Friendlier name for `library` — same recipe, "build the lua library"
+alias build := library
 
 # Build lua-doc-extractor from local checkout
 build-lde:
@@ -89,17 +94,37 @@ library-reload *flags: (library flags)
     -pkill -f lua-language-server
     @echo "LuaLS restarting (editor extension will respawn it)"
 
-# Reset generated Lua library files and restore lux-installed version
+# Reset generated Lua library files and restore lux-installed version.
+#
+# Scope: only the auto-generated tree (rts/Lua/library/generated/ and the
+# RecoilEngine subtree the extractor copies in). Hand-authored sources like
+# Types.lua, Spring.lua, RulesSyncedCallins.lua etc. are NOT touched —
+# `git checkout -- rts/Lua/library/` would have reverted in-progress edits
+# to those, which has bitten us before.
 reset:
     #!/usr/bin/env bash
     set -euo pipefail
     source "$DEVTOOLS_DIR/scripts/common.sh"
-    info "Resetting Lua library in RecoilEngine..."
+    info "Resetting generated Lua library in RecoilEngine..."
     cd "$RECOIL_DIR"
-    git checkout -- rts/Lua/library/
-    git clean -fd rts/Lua/library/
+    # `git clean -fd` removes untracked files (the generated tree is
+    # gitignored). `git checkout` is scoped to the subtree paths that ARE
+    # tracked there (none today, but safe against future drift).
+    git clean -fd rts/Lua/library/generated/ rts/Lua/library/RecoilEngine/ 2>/dev/null || true
+    git checkout -- rts/Lua/library/generated/ rts/Lua/library/RecoilEngine/ 2>/dev/null || true
     info "Restoring lux-installed recoil-lua-library..."
     cd "$BAR_DIR"
     lx sync
     just lua::link
     ok "Lua library reset."
+
+# Run the same lua-language-server check that CI runs, via the recoil-docs
+# compose service (which already has mise + lua-language-server set up).
+# Useful for catching @param/@field references to undefined types before push.
+#
+# Resets the library tree first so stale outputs from a previous run with a
+# different lua-doc-extractor version (e.g. the contexts branch's bucket
+# files: synced.lua / unsynced.lua / shared.lua) don't collide with the
+# fresh per-file outputs and produce phantom duplicate-doc-field warnings.
+check: reset
+    {{COMPOSE}} run --rm recoil-docs lua_check

--- a/just/lua.just
+++ b/just/lua.just
@@ -24,35 +24,7 @@ build-lde:
     npm ci && npm run build
     ok "lua-doc-extractor built"
 
-# Resolve the lux-installed path for recoil-lua-library
-[private]
-recoil-lib-path:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    match=$(find "$BAR_DIR/.lux/5.1" -maxdepth 2 -name 'src' -path '*recoil-lua-library*' -type d 2>/dev/null | head -1)
-    if [ -z "$match" ]; then
-        echo "$BAR_DIR/.lux/5.1/recoil-lua-library" # fallback before first sync
-    else
-        dirname "$match"
-    fi
-
-# Create symlink from BAR/recoil-lua-library -> lux-installed package
-link: recoil-lib-path
-    #!/usr/bin/env bash
-    set -euo pipefail
-    source "$DEVTOOLS_DIR/scripts/common.sh"
-    target=$(just lua::recoil-lib-path)
-    link="$BAR_DIR/recoil-lua-library"
-    if [ -L "$link" ]; then
-        rm "$link"
-    elif [ -e "$link" ]; then
-        warn "$link exists and is not a symlink, skipping"
-        exit 0
-    fi
-    ln -s "$target" "$link"
-    ok "Symlinked $link -> $target"
-
-# Generate Lua library from RecoilEngine sources, copy into lux-installed path
+# Generate Lua library from RecoilEngine sources, copy into BAR working tree
 library *flags: build-lde
     #!/usr/bin/env bash
     set -euo pipefail
@@ -74,27 +46,18 @@ library *flags: build-lde
         --repo "https://github.com/beyond-all-reason/RecoilEngine/blob/master" \
         {{flags}}
 
-    LUX_LIB=$(just lua::recoil-lib-path 2>/dev/null || echo "")
-    if [ -n "$LUX_LIB" ] && [ -d "$LUX_LIB" ]; then
-        info "Copying into lux-installed recoil-lua-library..."
-        clean_dir "$LUX_LIB/src"
-        mkdir -p "$LUX_LIB/src"
-        cp -r "$RECOIL_DIR/rts/Lua/library/"* "$LUX_LIB/src/"
-        ok "Updated $LUX_LIB/src/"
-        echo "  Run 'just lua::reset' to restore the published version."
-    else
-        info "Copying into BAR working tree..."
-        mkdir -p "$BAR_DIR/recoil-lua-library/src"
-        cp -r "$RECOIL_DIR/rts/Lua/library/"* "$BAR_DIR/recoil-lua-library/src/"
-        ok "Updated $BAR_DIR/recoil-lua-library/src/"
-    fi
+    info "Copying into BAR working tree..."
+    mkdir -p "$BAR_DIR/recoil-lua-library/src"
+    clean_dir "$BAR_DIR/recoil-lua-library/src"
+    cp -r "$RECOIL_DIR/rts/Lua/library/"* "$BAR_DIR/recoil-lua-library/src/"
+    ok "Updated $BAR_DIR/recoil-lua-library/src/"
 
 # Generate library then restart LuaLS so the editor picks up changes
 library-reload *flags: (library flags)
     -pkill -f lua-language-server
     @echo "LuaLS restarting (editor extension will respawn it)"
 
-# Reset generated Lua library files and restore lux-installed version.
+# Reset generated Lua library files in RecoilEngine.
 #
 # Scope: only the auto-generated tree (rts/Lua/library/generated/ and the
 # RecoilEngine subtree the extractor copies in). Hand-authored sources like
@@ -112,10 +75,6 @@ reset:
     # tracked there (none today, but safe against future drift).
     git clean -fd rts/Lua/library/generated/ rts/Lua/library/RecoilEngine/ 2>/dev/null || true
     git checkout -- rts/Lua/library/generated/ rts/Lua/library/RecoilEngine/ 2>/dev/null || true
-    info "Restoring lux-installed recoil-lua-library..."
-    cd "$BAR_DIR"
-    lx sync
-    just lua::link
     ok "Lua library reset."
 
 # Run the same lua-language-server check that CI runs, via the recoil-docs

--- a/just/lua.just
+++ b/just/lua.just
@@ -59,22 +59,17 @@ library-reload *flags: (library flags)
 
 # Reset generated Lua library files in RecoilEngine.
 #
-# Scope: only the auto-generated tree (rts/Lua/library/generated/ and the
-# RecoilEngine subtree the extractor copies in). Hand-authored sources like
-# Types.lua, Spring.lua, RulesSyncedCallins.lua etc. are NOT touched —
-# `git checkout -- rts/Lua/library/` would have reverted in-progress edits
-# to those, which has bitten us before.
+# `git clean -fdx` removes untracked + gitignored files only (`-fd` alone
+# skips gitignored, and the generated tree is gitignored). Tracked,
+# hand-authored sources like Types.lua, Spring.lua, RulesSyncedCallins.lua
+# are untouched.
 reset:
     #!/usr/bin/env bash
     set -euo pipefail
     source "$DEVTOOLS_DIR/scripts/common.sh"
     info "Resetting generated Lua library in RecoilEngine..."
     cd "$RECOIL_DIR"
-    # `git clean -fd` removes untracked files (the generated tree is
-    # gitignored). `git checkout` is scoped to the subtree paths that ARE
-    # tracked there (none today, but safe against future drift).
-    git clean -fd rts/Lua/library/generated/ rts/Lua/library/RecoilEngine/ 2>/dev/null || true
-    git checkout -- rts/Lua/library/generated/ rts/Lua/library/RecoilEngine/ 2>/dev/null || true
+    git clean -fdx rts/Lua/library/ 2>/dev/null || true
     ok "Lua library reset."
 
 # Run the same lua-language-server check that CI runs, via the recoil-docs
@@ -86,4 +81,13 @@ reset:
 # files: synced.lua / unsynced.lua / shared.lua) don't collide with the
 # fresh per-file outputs and produce phantom duplicate-doc-field warnings.
 check: reset
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Export HOST_UID/HOST_GID for docker compose's `${HOST_UID}:${HOST_GID}`
+    # substitution in docker-compose.dev.yml — `$UID` is a readonly bash
+    # builtin we can't `export` to override, hence the prefix. Without
+    # this, compose falls back to its 1000:1000 default, and on hosts
+    # where the user is uid 1001+ the generated tree ends up unwritable
+    # on subsequent runs.
+    export HOST_UID="$(id -u)" HOST_GID="$(id -g)"
     {{COMPOSE}} run --rm recoil-docs lua_check

--- a/just/lua.just
+++ b/just/lua.just
@@ -47,10 +47,10 @@ library *flags: build-lde
         {{flags}}
 
     info "Copying into BAR working tree..."
-    mkdir -p "$BAR_DIR/recoil-lua-library/src"
-    clean_dir "$BAR_DIR/recoil-lua-library/src"
-    cp -r "$RECOIL_DIR/rts/Lua/library/"* "$BAR_DIR/recoil-lua-library/src/"
-    ok "Updated $BAR_DIR/recoil-lua-library/src/"
+    mkdir -p "$BAR_DIR/recoil-lua-library/library"
+    clean_dir "$BAR_DIR/recoil-lua-library/library"
+    cp -r "$RECOIL_DIR/rts/Lua/library/"* "$BAR_DIR/recoil-lua-library/library/"
+    ok "Updated $BAR_DIR/recoil-lua-library/library/"
 
 # Generate library then restart LuaLS so the editor picks up changes
 library-reload *flags: (library flags)


### PR DESCRIPTION
* adds host permission pass through to mise so the doc generation can easily be wiped
* aliases `lua::library` to `lua::build` cuz helpful
* adds `lua::check` which runs the same check mise runs on the recoil lua (TODO in a follow up PR: convert the engine check to EmmyLua instead of Lua LS)