### PR TITLE
Launch

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(just bar::log)",
+      "Bash(just --list)",
+      "Bash(just --list *)",
+      "Bash(just --evaluate)",
+      "Bash(just doctor)"
+    ]
+  }
+}

--- a/.claude/skills/exactly-one-way/SKILL.md
+++ b/.claude/skills/exactly-one-way/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: exactly-one-way
+description: There should be exactly one way to do everything in this repo. Use this when reviewing or refactoring setup/sync code — it's the rule that drove removing `cmd_once`, `_have_watchman`, watchman-host-fallback, the distrobox-optional path, and the existence-check-before-recreate ceremony.
+---
+
+# Exactly one way
+
+Every operation has one path. Multiple paths to the "same" thing diverge over time, hide bugs in the unused branch, and force readers to figure out which is canonical.
+
+## Concrete applications
+
+- **Sync daemon start** — one entrypoint: `sync.sh start [--wait-ready]`. There is no `sync.sh once` and no "synchronous mode" flag. `--wait-ready` covers the "I want to know when it's done seeding" case.
+- **Cold copy** — one path: `_cold_copy_via_watchman`. There is no host-watchman fallback, no "detect-and-degrade" branch, no `if not have_watchman: rsync_full`. Watchman missing is a fail-loud SystemExit at the subprocess layer.
+- **Dev toolchain habitat** — distrobox, mandatory. There is no `--no-distrobox` flag, no "host-side install" alternative, no `command -v lx ||` host-fallback. The Containerfile is the toolchain spec.
+- **Watchman install** — `dnf` inside the container, period. Not "Fedora RPM if available else build from source else apt repo else zip extract". One path.
+- **Consent** — running the script is the consent. One press-Enter splash up front. No per-step Y/n.
+
+## The audit prompt
+
+When you see two ways to do something, ask:
+
+1. Is one of them load-bearing for a real platform? (e.g. WSL vs Linux is real; "host has watchman" vs "container has watchman" is not — it's a decision we made.)
+2. If both paths exist, what test exercises the non-default branch? If nothing does, delete that branch.
+3. Are we maintaining a fallback for an impossible state? (E.g. "what if watchman isn't installed even though sync.Containerfile installs it?" — that's a stale-container problem, fixed by always rebuilding, not by adding a fallback.)
+
+## What this rule does *not* mean
+
+- WSL and Linux paths legitimately differ (engine binary lives in different places, sync only matters on WSL). Real platform branches stay.
+- Configurability via `.env` (`BAR_DATA_DIR`, `ALLOW_SPRINGSETTINGS_MOD`) is fine. One mechanism (the env var), one read site, one decision point.
+
+## When tempted to add a second path
+
+Ask: would the user notice if we deleted the new path tomorrow? If no, don't add it. If yes — what's wrong with the existing path that we can't fix in place?

--- a/.claude/skills/front-load-prompts/SKILL.md
+++ b/.claude/skills/front-load-prompts/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: front-load-prompts
+description: All interactive decisions in long-running setup scripts go in one batch at the top, before any work runs. Use this when adding a new prompt to `cmd_init`, `setup::init`, or any multi-minute recipe — it explains the "Step 0/N Configuration" pattern and why we don't sprinkle Y/n prompts through the steps.
+---
+
+# Front-load prompts
+
+`setup::init` does ~5 minutes of distrobox image build + ~90 minutes of repo clones + ~45 minutes of engine build. Then, on Windows, potentially sync time. The contributor walks away during that time. **Every interactive prompt belongs before the first long-running step**, captured so a later step reads the answer instead of re-asking.
+
+## The Step 0 pattern
+
+`cmd_init`'s configuration phase (`step "0/N  Configuration"`) is a flat batch: detect what it can, ask every decision, then `confirm_setup_plan` rolls the lot up for one Y/n. Nothing below step 0 prompts.
+
+The prompts are not hand-written `read -rp` calls in `cmd_init` — each decision is a self-registering module under `scripts/setup/NN-<name>.sh`, driven by `ensure_module_by_name`. That mechanism is its own convention; see the **setup-module-registry** skill. The rule *this* skill carries is the ordering: a module's prompt fires in step 0, its `apply` runs whenever it has to (immediately, or deferred to the end of `cmd_init`), but the question is always asked up front.
+
+## Running setup::init is itself the consent
+
+`confirm_setup_plan` closes step 0 with a rollup — every decision the user made, plus the work ahead (repos to clone, whether the distrobox build is still pending, a sudo heads-up) — and a single Y/n. That is the one generic gate. Once the user confirms it, **they have consented to the script running**: no per-step "Install X? [Y/n]". If they want out, they Ctrl-C.
+
+So any sub-tool with an interactive default needs its non-interactive flag — `distrobox stop --yes`, `distrobox rm -f --yes`, `distrobox create --yes`, `apt install -y`. A prompt that fires past step 0 is the bug.
+
+## Ask up front, act later
+
+The load-bearing example is the symlink decision. The question ("symlink the selected components into the game dir after build?") is asked in step 0, when the user is paying attention, and persisted to `.env`. Step 6 ("Symlinks") just acts on the saved answer, or prints `Skipping symlinks (declined at configuration step)`. Same shape for any "should I do X" decision: the prompt goes in step 0, the work goes wherever it has to.
+
+## Audit checklist when adding a step
+
+- Does the step have a `read -rp` or Y/n prompt? → it doesn't belong there. Make it a setup module (see **setup-module-registry**) so the prompt lands in step 0 and the answer persists to `.env`.
+- Does the step call a sub-tool with an interactive default? → add `--yes` / `-y` / `--non-interactive`.
+- Is the prompt conditional on detection that needs earlier setup (e.g. `detect_game_dir`)? → fine, but the prompt still goes in step 0 *after* the detection, not buried in a later step.

--- a/.claude/skills/front-load-prompts/SKILL.md
+++ b/.claude/skills/front-load-prompts/SKILL.md
@@ -5,7 +5,7 @@ description: All interactive decisions in long-running setup scripts go in one b
 
 # Front-load prompts
 
-`setup::init` does ~5 minutes of distrobox image build + ~90 minutes of repo clones + ~45 minutes of engine build. Then, on Windows, potentially sync time. The contributor walks away during that time. **Every interactive prompt belongs before the first long-running step**, captured so a later step reads the answer instead of re-asking.
+`setup::init` does ~5 minutes of distrobox image build + ~90 minutes of repo clones + ~45 minutes of engine build. Then, on Windows, sync time. The contributor walks away during that time. **Every interactive prompt belongs before the first long-running step**, captured so a later step reads the answer instead of re-asking.
 
 ## The Step 0 pattern
 

--- a/.claude/skills/setup-module-registry/SKILL.md
+++ b/.claude/skills/setup-module-registry/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: setup-module-registry
+description: Every cmd_init step except system-deps lives in scripts/setup/NN-<name>.sh as a self-registering "module" with a uniform read/prompt/write/apply contract. Use this when adding a new setup-time decision, refactoring a `read -rp` that re-asks on re-runs, or wiring a setting into `just doctor`.
+---
+
+# Setup module registry
+
+`setup::init` is idempotent and re-runnable — after a partial failure, to pick up a newly-selected feature, or via `setup::reconfigure`. Every decision it prompts for has to persist, or that re-run re-asks it. A bare `read -rp` that writes only a local variable is exactly that leak; this convention closes it by giving every decision a `.env`-backed home that the engine reads before deciding whether to prompt.
+
+## The contract
+
+Every setup decision lives in its own file under `scripts/setup/NN-<name>.sh`:
+
+```bash
+#!/usr/bin/env bash
+# shellcheck source=scripts/setup/_lib.sh
+# Module: <name>.
+
+prompt_<name>() {
+    # Interactive picker. On success, calls write_env_key <KEY> <value>.
+    # No materialization side effects -- writing to .env is the only
+    # state mutation here.
+}
+
+apply_<name>() {
+    # Read the persisted value via read_env_key <KEY> and do the real
+    # work. No prompts, no .env writes. Idempotent: must be safe to
+    # call repeatedly.
+}
+
+register_module <name> <KEY> prompt_<name> apply_<name> [<when>] [<features>]
+```
+
+`<when>` (`config` default | `deferred`) and `<features>` (a comma-list
+feature gate; empty = always relevant) are optional — see the two sections
+below.
+
+`scripts/setup/_lib.sh` is the engine. It exposes:
+
+- `register_module` — validates that `prompt_fn` / `apply_fn` are real defined functions at source time (catches typos before any user sees them) and appends to `SETUP_MODULES`.
+- `read_env_key <KEY>` / `write_env_key <KEY> <VAL>` — single source of truth for `.env` I/O. Don't hand-roll grep/sed for `.env`; use these. **They live in `scripts/common.sh`**, not `_lib.sh`: they're generic persistence helpers (CLAUDE.md: ".env is the persistence layer"), not registry internals. `common.sh` is sourced before `_lib.sh` everywhere, so the engine still resolves them.
+- `module_relevant <name>` — true if the module's `<features>` gate is empty or overlaps the live `BAR_FEATURES` selection (via `feature_selected`, also in `common.sh`). `cmd_init` wraps each gated module's `ensure_module_by_name` in it; `summarize_modules` / `apply_deferred_modules` skip the modules it rejects.
+- `ensure_module <entry>` — drives one module: read existing value; if empty (or `BAR_RESET_CONFIG=1`), call `prompt_<name>`; then call `apply_<name>`.
+- `ensure_module_by_name <name>` — same, looked up by registered name. Used by `just <module>::setup` recipes so they share lifecycle with `cmd_init`.
+- `ensure_all_modules` — iterate every module in registration order with auto-numbered `step` headers.
+- `doctor_modules` — read-only iteration; prints the registry as a table for `just doctor`. Deliberately **not** gated by `module_relevant` — an `<unset>` row for a gated-out module is a valid diagnostic.
+- `summarize_modules` — read-only iteration for `confirm_setup_plan`'s pre-flight rollup; prints a module's optional `summary_<name>` if defined, else the raw `KEY = value`. Skips modules `module_relevant` rejects.
+
+`cmd_init`'s configuration phase becomes a flat sequence of `ensure_module_by_name <name>` calls. There is **no `read -rp` outside a module file** — that's what caused the re-ask leaks before this convention.
+
+## Selection vs action modules
+
+Modules fall into two shapes:
+
+- **Action modules** materialize at config time. `apply_<name>` does the work immediately after the prompt:
+  - `chobby_channel`: writes `<data-dir>/chobby_config.json`.
+  - `ssh`: runs `scripts/ssh/setup-<choice>-ssh.sh`.
+- **Selection modules** record a value that downstream steps in `cmd_init` consume:
+  - `features`: persists `BAR_FEATURES`; clone/build/link steps read it via `read_env_key`.
+  - `link_on_build`: persists `BAR_LINK_ON_BUILD`; the symlinks step at the end of `cmd_init` reads it.
+
+For selection modules, `apply_<name>() { :; }` (true no-op). The downstream code in `cmd_init` uses `read_env_key BAR_<KEY>` to drive its decision. **Do not duplicate the apply logic between the module and `cmd_init`** — pick one home; selection modules put the home in `cmd_init`'s ordered phases, action modules put the home in `apply_<name>`.
+
+## Deferred apply: `register_module ... deferred`
+
+Some modules' apply touches state that `cmd_init` only creates *later* (clones, builds, the bar-dev distrobox). Running their apply during the front-loaded config phase explodes because that state isn't there yet.
+
+The fifth argument to `register_module` is `when`, defaulting to `config`. Pass `deferred` for modules that need to wait:
+
+```bash
+# editor's apply runs distrobox-export, which needs the bar-dev container
+# created at cmd_init step 2/N. Tagging deferred so prompt fires at config
+# time (front-loaded) but apply waits until apply_deferred_modules is called
+# at the end of cmd_init.
+register_module editor BAR_EDITOR_SETUP prompt_editor apply_editor deferred bar,recoil
+```
+
+`ensure_module` for a deferred module runs only the prompt; `apply_deferred_modules` (called near the end of `cmd_init`, after distrobox/clones/builds) iterates and runs the deferred applies. The user still sees one prompt batch at the top — the apply just shifts in time.
+
+This is bash's stand-in for the `depends-on` graph a real config-management tool would express. Keep deferred to the genuinely-needs-later-state cases; don't tag everything deferred to "be safe".
+
+## Feature-gating: the 6th `register_module` arg
+
+A module relevant only to some features takes a comma-list `<features>` gate
+as the sixth argument. `module_relevant` is true when the gate is empty *or*
+overlaps the live `BAR_FEATURES`; `cmd_init` wraps the module's
+`ensure_module_by_name` in `if module_relevant <name>; then ...; fi`, and
+`summarize_modules` / `apply_deferred_modules` skip what it rejects. So a
+teiserver-only contributor is never asked about the Chobby channel,
+springsettings, the editor toolchain, or game-dir symlinks.
+
+The sixth arg sits *after* `<when>`, so a gated module must state `<when>`
+explicitly even when it's the `config` default:
+
+```bash
+register_module springsettings ALLOW_SPRINGSETTINGS_MOD \
+    prompt_springsettings apply_springsettings config bar,recoil
+```
+
+`features` and `ssh` are ungated (every selection clones repos and may need
+SSH). The gate lives at the `cmd_init` call site only — `just <module>::setup`
+still re-prompts any module directly, gate or no gate. Keep gates honest:
+list the features a module's decision actually affects, nothing more.
+
+## Fail loudly inside apply_
+
+`set -e` propagates non-zero through bare commands but **not** through pipes (without `pipefail`), through `2>/dev/null` swallowed errors, or through unchecked loop iterations. Several silent-failure shapes used to hide here:
+
+- **Loops over commands without per-iteration check.** The original `for bin in ...; do distrobox-export "$bin" ...; done` swallowed each export's exit code. Fix: capture exit, accumulate failures, `err`+`return 1` at the end of the loop. Whoever runs `setup::init` finds out *which* binary failed.
+- **`cmd | tail -3` style pipes.** `tail` always succeeds; cmd's exit goes nowhere. Fix: `set -eo pipefail` inside the `bash -c`, or `${PIPESTATUS[0]}` checks.
+- **`bash -c '<multi-line>'` without `set -e` inside.** The inner script keeps going past failures by default. Fix: first line of the inner script is `set -e`.
+- **Bare `echo "$cmd" 2>/dev/null`** that masks all errors. Only acceptable for genuinely-expected failures (probe-and-fall-back); not for installs/exports/configures.
+
+Pattern: every apply_ should either succeed cleanly OR `err`+`return 1`. The user-visible message tells them what failed and how to recover (`Re-run 'just setup::editor'`, `Run 'just setup::distrobox' first`).
+
+`cmd_init` keeps its `ensure_module_by_name <name> || true` wrappers so a single module's apply failure doesn't abort the whole flow — but the module's loud err is what tells the user which module failed and what to do.
+
+## File layout and order
+
+```
+scripts/setup/
+├── _lib.sh                # engine. Skipped by the loader (underscored).
+├── 20-features.sh
+├── 25-link-on-build.sh
+├── 30-chobby-channel.sh
+├── 40-ssh.sh
+├── 50-editor.sh
+└── 60-springsettings.sh
+```
+
+The loader globs `[0-9]*.sh` in alphanumeric order. **Use the numeric prefix as a topological hint**: a module that needs another module's value already in `.env` should come after it. (e.g. `chobby_channel` needs `BAR_DATA_DIR` from earlier; the prefix `30` puts it after the data-dir resolution.) Don't do a runtime topological sort — the prefix IS the convention.
+
+`_load_setup_modules` is called from the **bottom of `setup.sh`**, after every helper the modules call (`checkbox_list`, `info`/`warn`, repo helpers, `read_env_key`) is already defined. Modules can't use forward references.
+
+## Why bash, what intellisense looks like
+
+Setup runs before `python3`, `pipx`, and `distrobox` are guaranteed to exist. A Python rewrite makes orchestration cleaner but introduces a bootstrap problem worse than the orchestration itself. Stay in bash; mitigate the stringly-typed function-pointer cost with discipline:
+
+- `register_module` runs `declare -F "$prompt_fn"` and `declare -F "$apply_fn"` — typos surface at source-load, not at user-prompt time.
+- Strict naming: `prompt_<name>`, `apply_<name>`, `read_<name>` / `summary_<name>` (both optional). Grep is the index.
+- `# shellcheck source=scripts/setup/_lib.sh` directive at the top of each module file keeps shellcheck cross-file checks working.
+- The engine itself (`ensure_module` / `_load_module_entry`) is ~30 lines. Trace it once; the indirection cost is bounded.
+
+## Adding a module
+
+1. Pick a number prefix that places it after any module whose `.env` value yours depends on, before any module that depends on yours.
+2. Drop a file at `scripts/setup/NN-<name>.sh` with `prompt_<name>` + `apply_<name>` + `register_module`.
+3. Wire it into `cmd_init` with `ensure_module_by_name <name> || true` (the `|| true` lets a module decline gracefully — e.g., `prompt_features` returning 1 if the user picked nothing). If the decision is feature-specific, give `register_module` a 6th `<features>` arg and wrap the call in `if module_relevant <name>; then ...; fi`.
+4. (Action module only) — make sure `apply_<name>` is idempotent: re-running on a 2nd `setup::init` invocation must not do destructive work. The pattern is: read current state, compare to desired, no-op if equal.
+5. (Selection module only) — wire the downstream consumer to read `BAR_<KEY>` via `read_env_key`, not from a local-variable holdover.
+6. Add a recipe `just <module>::setup` whose body is `ensure_module_by_name <name>` if standalone re-prompting is useful (`bar::dev-mode` is the precedent: it calls `apply_chobby_channel` directly because the recipe's whole job is "force the value" without re-prompting).
+
+## What this convention disallows
+
+- `read -rp` anywhere outside `prompt_<name>`. If you're reaching for it, write a module instead.
+- Hand-rolled `.env` reads/writes. Use `read_env_key` / `write_env_key`.
+- "Skip if .env has the key" guards inside `prompt_<name>`. `ensure_module` owns that gate. A second in-prompt guard silently ignores `BAR_RESET_CONFIG` — exactly the bug that wedged `setup::reconfigure` until the legacy `prompt_ssh_setup_choice` / `prompt_editor_setup_choice` / `prompt_springsettings_opt_in` guards were removed. A prompt may still short-circuit on a *probe* (e.g. ssh's `_github_ssh_works` autodetect) — but gate that on `BAR_RESET_CONFIG` so a reconfigure still asks.
+- Cross-module reaches in `apply_<name>`. If you need `BAR_DATA_DIR` from inside `apply_chobby_channel`, call `read_env_key BAR_DATA_DIR`. Don't depend on call ordering or shared globals.
+
+## What's special about `cmd_doctor`
+
+`check_doctor_modules` calls `doctor_modules`, which iterates `SETUP_MODULES` and prints `<name> <KEY> <value>`. **Adding a module gets you a doctor row for free** — no separate doctor-side hardcoded list to update. This was the load-bearing reason for picking the registry over the simpler `_module_lifecycle` helper: doctor stays in sync without anyone remembering to update it.
+
+## The escape hatch: `BAR_RESET_CONFIG=1`
+
+`ensure_module` checks `${BAR_RESET_CONFIG:-}` before consulting `.env`. Setting it to anything non-empty forces every module to re-prompt regardless of persisted state. One knob, applied uniformly because every module reads it the same way through the engine. Don't add per-module reset flags.

--- a/.claude/skills/terse-comments/SKILL.md
+++ b/.claude/skills/terse-comments/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: terse-comments
+description: Code comments are terse or absent — never multi-line rationale blocks, never narration of what the next line does, never explaining what's missing or why-not. Use when writing or editing any code file (.sh, .just, Containerfile, .py, compose). The repo owner and BAR contributors treat verbose comment blocks as AI clutter.
+---
+
+# Terse comments
+
+Code aesthetic and brevity beat exhaustive reasoning. A wall of comment is tiring to read, reads as AI-written, and detracts from the code. Humans don't write them — and BAR contributors notice and dislike them.
+
+## The rule
+
+Default to **no comment**. Write one only for a genuine non-obvious gotcha — a constraint a maintainer would actually trip over — and then **one terse line**, never a paragraph.
+
+## Don't
+
+- Multi-line rationale blocks above a function or stanza.
+- Narration — a comment that restates what the next line(s) do.
+- Explaining what's *missing* or *why-not*: `# No X here because…`, `# we don't touch Y…`. Absent code needs no comment.
+- Decorative banners and section dividers.
+- Function-header essays describing args, returns, and history.
+
+## Do
+
+- One terse line for a real gotcha: `# Plan 9 doesn't forward inotify from /mnt/c -- poll instead`.
+- Match the sparse comment density of the surrounding human-written code.
+- Let names and structure carry the meaning. If a block needs a paragraph to explain, the fix is usually clearer code, not a longer comment.
+
+The "why" belongs in the commit message — and, for a load-bearing design rule, a skill — not sprinkled across every line.
+
+## Scope
+
+Code files: `.sh`, `.just`, `Containerfile`, `.py`, compose YAML. Prose docs (`.md`, `README`, skill files) are exempt — they are meant to be read as prose.

--- a/.claude/skills/trust-the-container/SKILL.md
+++ b/.claude/skills/trust-the-container/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: trust-the-container
+description: Don't probe inside the bar-dev distrobox container for things `dev.Containerfile` is supposed to install. Use this when touching `setup.sh`, `dev.Containerfile`, or distrobox-related plumbing — it explains why we removed several layers of "diligent" if-statements and what to do instead.
+---
+
+# Trust the container
+
+`dev.Containerfile` is the single source of truth for what's in `bar-dev`. Once `cmd_setup_distrobox` has built and created the container, every binary listed in the Containerfile is there. Probing for those binaries from setup.sh is unnecessary diligence: it adds friction, drifts from the Containerfile, and makes failures less informative, not more.
+
+## Rules
+
+1. **No `command -v X` checks against the container's contents.** If `dev.Containerfile` says `dnf install watchman`, watchman is in the container. Don't `distrobox enter -- command -v watchman` to confirm. Don't print a `[warn]` if it's missing.
+2. **No "stale container, rebuild" self-heal logic.** `setup::init` already calls `cmd_setup_distrobox` unconditionally; that recipe always rebuilds against the current Containerfile. Adding a second rebuild path inside `ensure_*` helpers is duplicate plumbing.
+3. **No existence check before `distrobox stop` / `rm`.** Both are idempotent and silent on absence with `--yes` + `>/dev/null 2>&1`. The "already exists, recreating" warn was a UX wart; the fix was to drop the check, not gate it.
+4. **Use `/usr/bin/<name>` paths in `distrobox-export`.** When the package manager controls install location, use the path it writes to. Don't `distrobox enter -- command -v <name>` to discover it at runtime.
+5. **Let real failures surface.** If watchman isn't on the host PATH at runtime, `subprocess.run(["watchman", ...])` raises `FileNotFoundError` — that's the loud failure we want. Don't add `if not shutil.which("watchman")` guards that print friendlier error messages and then `raise SystemExit`. The friendlier message rots, the underlying failure is plenty clear.
+
+## Pinning RPM/ABI compatibility
+
+The container's base image must match the ABI the toolchain RPMs were built against. Watchman ships `.fc42.x86_64.rpm`; the Containerfile's `FROM` line is `fedora:42`, not `fedora:latest`. **When bumping the watchman version, bump the Fedora pin in lockstep.** This is the one place where being explicit about the Containerfile's environment matters more than convenience.
+
+## Toolchain layout
+
+Everything dev-toolchain — `emmylua_ls`, `clangd`, `stylua`, `lux`, `watchman`, `cargo`, `rust`, `nodejs`, `just`, `gcc` — lives in the container. Host-side we install only what runs at the OS layer: `git`, `docker`, `distrobox`, `python3-watchdog`, `inotify-tools`, `rsync`. If you find yourself adding a new dev tool: it goes in `dev.Containerfile`, exported via `distrobox-export` if it needs to run on the host.
+
+## What the host *does* legitimately probe
+
+- `command -v git`, `command -v docker`, `command -v distrobox` — host installation status. These genuinely may be missing (the deps step installs them).
+- `python3 -c 'import watchdog'`, `command -v rsync`, `command -v inotifywait` — these are host-side because `sync.py` runs on the host (it watches `/home/daniel/code` and writes to `/mnt/c`, neither of which the container can see).
+- `fs.inotify.max_user_watches` — kernel sysctl, lives on the host.
+
+If you're not sure whether a check is "host probing" or "container probing", look at where the binary needs to be invoked from. Host PATH = host probe = legitimate. Inside `distrobox enter` = stop and reconsider.

--- a/.claude/skills/wsl2-sync-architecture/SKILL.md
+++ b/.claude/skills/wsl2-sync-architecture/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: wsl2-sync-architecture
+description: Hard-won facts about the WSL2 ↔ Windows sync daemon (sync.py, sync.sh, launch.sh). Read this before changing how files cross the WSL/Windows boundary, before adjusting watchman/rsync invocations, before "improving" the cold-copy path, or before proposing a different sync architecture.
+---
+
+# WSL2 sync architecture
+
+## Architecture name
+
+`wsl-watchman-mntc`. The convention is `<watcher-host>-<event-source>-<destination>`:
+
+- watcher-host: where the watcher process runs (`wsl` or `win`)
+- event-source: how it learns about changes (`watchman`, `watchdog`, `inotifywait`, `detect`)
+- destination: where it writes (`mntc` = `/mnt/c`, `unc` = `\\wsl$\...`)
+
+When proposing or evaluating a sync change, name it this way. The probe set that settled the **WSL-side watcher** decision was (iii) `win-watchdog-unc`, (iv) `wsl-watchdog-mntc` (python-`watchdog`), (v) `wsl-detect-win-copy`, (vi) `wsl-inotifywait-mntc`; arm (iv) won. The **shipped daemon refines that**: the watcher runs WSL-side (as the probe concluded) but the event source is **Watchman**, not the python-`watchdog` library — Watchman was already required for the cold `since <clock>` delta path (below), so `sync.py` unifies on it for live subscriptions too and tracks all file state through it. Production is therefore `wsl-watchman-mntc`. Don't confuse Facebook **Watchman** (what we ship) with the python **watchdog** library (the probe arm). Probe data lives in `bar-design-docs/bifurcated_types/dev_setup_restructured.md`.
+
+## Boundary facts (do not relitigate without a fresh probe)
+
+- **Plan 9 does not forward inotify across the WSL/Windows boundary.** A native watchdog Observer on the Windows side watching `\\wsl$\...` silently degrades to `PollingObserver` (stat-loop). Production must run the watcher on the Linux side.
+- **`/mnt/c` ≠ NTFS native.** drvfs adds per-stat round-trips. `rsync` against `/mnt/c` is correct but slow (~80s stat-walk on the BAR tree). That's why we use Watchman to skip the walk.
+- **Windows holds DLL handles.** When `spring.exe` or `Beyond-All-Reason.exe` is running, rsync from Linux through drvfs to engine DLLs hits `EACCES` (rsync exit 23). `bar::stop` (`launch.sh`'s `stop_wsl`) kills these holders before `engine::build` runs.
+- **mmap inode stability.** The engine mmaps Lua sources. If a sync replaces the file via tempfile + rename, the inode flips under the live mmap and the engine reads garbage. **Always use `rsync --inplace`** — for both cold copies *and* per-event mirrors (`sync.py:_apply_files` re-runs `rsync -a --inplace --files-from=-` on each coalesced Watchman batch). Never `shutil.move`, `shutil.copyfile`+rename, or any rename-into-place.
+- **inotify watch limits.** Default 8192 is below BAR's directory count. `setup::init` bumps `fs.inotify.max_user_watches` to 524288 via `/etc/sysctl.d/99-bar-devtools.conf`.
+
+## Watchman is mandatory, no fallback
+
+- Watchman lives **inside the WSL2-only `bar-sync` distrobox** (installed by `docker/sync.Containerfile`), and `sync.py` runs *inside* that container — `scripts/sync.sh` launches it via `distrobox enter bar-sync -- … sync.py`. It is **not** in the `bar-dev` toolchain container; see the ABI note below for why it's quarantined.
+- `sync.py` imports `pywatchman` at module load and exits hard (`SystemExit(1)`) if it's missing — there is no `_have_watchman()` guard and no silent fallback. We want the loud failure, not a silent ~80s rsync stat-walk on `/mnt/c` that contributors mistake for normal. The daemon talks to the Watchman service via `pywatchman.client()` and drives everything off subscriptions.
+- First call for a `(src, dst)` pair: `watch-project` + initial `clock` + full rsync seed. Subsequent calls: `since <clock>` query + rsync `--files-from` for changed files only + unlink for deletions.
+- Pair state is persisted to `${XDG_STATE_HOME:-~/.local/state}/bar-devtools/sync-state-<sha1>.json` via atomic rename + fsync. (Lives on Linux ext4 — NOT under `$BAR_DATA_DIR` on /mnt/c — so watchman clock tokens survive daemon restarts without paying drvfs costs every read.)
+
+## Watchman / Fedora / RPM ABI
+
+The watchman RPM Meta publishes is built against a specific Fedora release. This is exactly why Watchman is quarantined in its own `bar-sync` container instead of the `bar-dev` toolchain container: it lets `dev.Containerfile` track current Fedora (`fedora:43`) while **`sync.Containerfile` stays pinned to the watchman-compatible release.** As of `v2026.05.04.00` that's `fedora:42` (boost 1.83, libglog.so.0, libdwarf.so.0 — the last of which fc43 dropped). Bumping `sync.Containerfile` to `fedora:latest` will break the install with "nothing provides libboost_context.so.1.83.0" et al. When bumping `WATCHMAN_VERSION`: bump `sync.Containerfile`'s `FROM` line in lockstep. (`bar-sync` is only built on WSL2, so Linux/macOS contributors never hit this.)
+
+## Daemon lifecycle
+
+- `sync.sh start [--wait-ready]` — spawns one `sync.py` per pair; readiness is the `READY` line in the log. `--wait-ready` tails the log and blocks until ready or the daemon dies.
+- `sync.sh stop` — SIGTERM, then SIGKILL.
+- **Validate pair list before "already running" early-return.** A stale pid file with a daemon already up should not skip pair validation; otherwise a missing source symlink stays silent.
+- **Drift detection.** If the pair list passed to `start` differs from the pair list the running daemon was started with, restart the daemon.
+- The engine pair is excluded from the watcher because `engine::build` rsyncs into the same target. A live watcher would race the build.
+
+## Logging discipline
+
+- One `FileHandler` only when `--log` is set. Adding a `StreamHandler(stderr)` while shell redirects stderr to the log file double-writes every line.
+- Per-event mirrors log at `INFO` (not `DEBUG`) — the user wants to see what synced.
+- Startup line includes the inotify watch limit, the chosen Observer class (native vs polling), and the watchman version.
+- Signals are logged by name (`SIGTERM (kill)`, `SIGINT (Ctrl-C)`, `SIGHUP (terminal closed)`) with recovery hints (`just bar::stop`, `just link::create`) — never just "received signal 15".
+
+## Re-probing the sync decision
+
+`wsl-watchdog-mntc` was picked by measuring all six candidate architectures end-to-end with `scripts/probe_wsl_sync.py` — not by reasoning from first principles. A Windows-side watcher *felt* obvious; Plan 9 not forwarding inotify is what killed it. Don't relitigate the boundary facts above from a comment thread — re-run the probe.
+
+Re-probe when:
+
+- WSL has a major version change (1 → 2 was an inotify boundary; a future one might shift again).
+- Watchdog / Watchman / rsync has a major bump touching the OS abstraction layer.
+- The watched tree's file count grows ~10×.
+- Someone proposes "just use X" where X is one of the rejected arms — re-run before deciding the platform changed.
+
+A probe that earns a decision measures, on real hardware:
+
+- **Median + p99 round-trip** — edit on source → *content-equal* on destination. Equality, not first-byte: partial-write windows matter.
+- **Cold-start cost** — seed an empty destination with N files; this is what users feel on first daemon launch.
+- **Steady-state per-event cost** — individual edits after the seed.
+- **Failure modes** — kill the watcher mid-edit, exhaust the watch limit, hit `EACCES` on locked files. The architecture has to survive these, not just win the happy-path benchmark.
+
+And it documents its preconditions: if the result depends on `fs.inotify.max_user_watches=524288`, production must enforce that (`ensure_sync_daemon_deps_wsl`) — a probe that passes only because of a sysctl production never sets is a lie. Keep `scripts/probe_wsl_sync.py` runnable so the decision stays reproducible; killed candidates and their numbers live in `bar-design-docs/bifurcated_types/dev_setup_restructured.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,18 @@
-# Cloned repositories (managed via repos.conf)
-teiserver/
-bar-lobby/
-spads_config_bar/
-ansible-spads-setup/
+# Cloned repositories (managed via repos.conf — match dirs and symlinks, so
+# `@local_root` symlinks aren't accidentally committed).
+teiserver
+bar-lobby
+spads_config_bar
+ansible-spads-setup
 Beyond-All-Reason
 BYAR-Chobby
-bar-db/
-bar-live-services/
+bar-db
+bar-live-services
 RecoilEngine
 lua-doc-extractor
-SPADS/
-SpringLobbyInterface/
+SPADS
+SpringLobbyInterface
+bar_debug_launcher
 
 # Personal config overrides
 repos.local.conf
@@ -19,4 +21,11 @@ repos.local.conf
 # Runtime / editor state
 tasks/
 .devtools/
+.backups/
 *.log
+bar-lua-codemod/target/
+.claude/settings.local.json
+.claude/projects/
+.claude/todos/
+.claude/cache/
+__pycache__/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+BAR-Devtools is an **orchestrator**, not an application. It clones several sibling repositories (`Beyond-All-Reason`, `RecoilEngine`, `teiserver`, `bar-lobby`, `BYAR-Chobby`, `spads_config_bar`, `lua-doc-extractor`) into this directory (gitignored) and provides `just` recipes that operate across them. Most "BAR-Devtools" work is touching scripts that drive the cloned repos, not editing the cloned repos themselves.
+
+Many recipes assume the bar-dev distrobox container exists. `dev.Containerfile` is the canonical manifest of dev-tool dependencies — Lua 5.1, lx (lumen-oss/lux), Node, Cargo, clangd, StyLua, EmmyLua. Recipes that need those tools call `enter_distrobox` from `scripts/common.sh` to re-exec inside the container.
+
+## Common commands
+
+```bash
+just doctor                 # read-only env audit (run this first when debugging)
+just --list                 # all top-level modules
+just <module>::              # list a module's recipes
+
+just setup::init            # one-time full setup (front-loads all prompts, then unattended)
+just setup::distrobox       # rebuild just the bar-dev container
+just setup::editor          # re-wire VS Code / Cursor language servers
+
+just bar::fmt               # stylua across BAR
+just bar::lint              # luacheck via lx
+just bar::units             # busted unit tests via lx
+just bar::units-shell       # interactive busted shell (--test + --no-loader)
+just bar::lx-shell          # general lx shell for `lx add`, `lx sync`, etc.
+
+just tei::test [path]       # teiserver mix tests (single file by path)
+just tei::setup-test-db     # re-run after pulling teiserver migrations
+
+just engine::build linux    # RecoilEngine via docker-build-v2
+just link::create engine    # symlink into game data dir
+
+just services::up [svc...]  # postgres + teiserver (+ optional spads, lobby)
+just services::logs <svc>   # tail container logs
+just services::reset        # nuke volumes and restart (destructive)
+
+just repos::clone [repo]    # clone or sync per repos.conf / repos.local.conf
+```
+
+## Architecture (non-obvious parts)
+
+### just module layout
+
+`Justfile` declares modules; each `just/<mod>.just` is a self-contained recipe set. Recipes share helpers via `scripts/common.sh` (sourced at the top of each multi-line recipe body). `enter_distrobox` is the key boundary helper — recipes that need lx / busted / stylua / emmylua call it to re-exec inside `bar-dev`.
+
+### setup is split
+
+- **`scripts/setup.sh`** is monolithic and runs in a fixed order (deps → docker → distrobox → repos → engine → editor → ...). Top-level orchestration only.
+- **`scripts/setup/NN-<name>.sh`** are self-registering modules with a uniform read/prompt/write/apply contract. Setup-time *decisions* live here, not in `setup.sh`. Adding a new prompt? It belongs in a new module file under `scripts/setup/`. See `.claude/skills/setup-module-registry/`.
+
+### Two distroboxes
+
+- `bar-dev` — built from `docker/dev.Containerfile`. The dev toolchain. Every contributor has it.
+- `bar-sync` — built from `docker/sync.Containerfile`. **WSL-only.** Hosts the `wsl-watchdog-mntc` sync daemon (`scripts/sync.py`, `scripts/sync.sh`). Linux-native contributors never run this — don't bundle its deps into `dev.Containerfile`.
+
+### `repos.conf` + `repos.local.conf`
+
+`repos.conf` is the upstream default. `repos.local.conf` (gitignored) overrides per-repo URL/branch and can replace a clone with a symlink via a 5th column. `scripts/repos.sh` parses both and feeds `just repos::clone`.
+
+### Service stack
+
+`docker-compose.dev.yml` defines postgres + teiserver + (optional) spads + (optional) bar-lobby. `bar-lobby` runs natively, not in Docker, despite being in the compose file as a convenience target. Teiserver's first boot seeds the DB and creates a `spadsbot` account; this is handled by `docker/teiserver-entrypoint.sh`.
+
+## Rules encoded as skills
+
+`.claude/skills/` contains six skill files. They are the project's design rules — read the relevant one before changing the area it covers, even if a different approach seems obvious:
+
+- **exactly-one-way** — every operation has one path; no `_have_X` fallbacks, no "if X exists else Y" ceremony around things `setup::*` already establishes. Touched when reviewing/refactoring setup or sync.
+- **front-load-prompts** — every interactive decision in a long-running recipe is asked in the Step 0 batch up front, never mid-run. Touched when adding interactive decisions to `cmd_init` or any multi-minute recipe.
+- **setup-module-registry** — adding a setup-time decision → new file under `scripts/setup/NN-<name>.sh` using the read/prompt/write/apply contract.
+- **terse-comments** — comments are terse or absent; never multi-line rationale, narration, or "what's missing" notes. Touched when writing or editing any code file.
+- **trust-the-container** — don't probe inside `bar-dev` for binaries that `dev.Containerfile` installs. Touched when editing `setup.sh`, `dev.Containerfile`, or distrobox-related plumbing.
+- **wsl2-sync-architecture** — hard-won facts about the WSL2 ↔ Windows boundary, including when to re-probe the sync architecture and what a probe must measure. Read before changing `sync.py`, `sync.sh`, `launch.sh`, or watchman/rsync invocations.
+
+## Cross-repo conventions
+
+- **lx version pin.** `docker/dev.Containerfile` (`LUX_VERSION`) and the BAR repo's `.github/workflows/test_unit.yml` must move in lockstep. Lockfile integrity checks differ between minor versions; skew makes locally regenerated `lux.lock` files fail CI (and vice versa).
+- **Editor wrappers in `~/.local/bin`.** `setup::editor` exports `lx`, `stylua`, `emmylua_ls`, `emmylua_check`, `clangd` from the container via `distrobox-export`. Host-side editors (VS Code, Cursor) find these on PATH. Do not check for them inside the container — the wrappers are a host-side concern.
+- **`.env` is the persistence layer.** Justfile uses `set dotenv-load`. Setup modules write decisions there (`BAR_DATA_DIR`, `DEVTOOLS_DISTROBOX`, feature flags). Don't read user state from any other location.

--- a/Justfile
+++ b/Justfile
@@ -9,13 +9,14 @@ mod lua      'just/lua.just'
 mod docs     'just/docs.just'
 mod bar      'just/bar.just'
 mod tei      'just/tei.just'
-
-# Diagnose your dev environment (read-only, no side effects)
-doctor:
-    just setup::doctor
+mod ssh      'just/ssh.just'
 
 default:
     @just --list --list-submodules
+
+# Diagnose your dev environment (read-only)
+doctor:
+    just setup::doctor
 
 reset:
     just lua::reset

--- a/README.md
+++ b/README.md
@@ -83,54 +83,10 @@ Starship's defaults use Nerd Font glyphs, which render as boxes without one inst
 
 </details>
 
-## Requirements
+<details>
+<summary><strong>VS Code test switcher</strong></summary>
 
-- **Linux** (Arch, Debian/Ubuntu, Fedora) -- or **Windows** via WSL2 (see below)
-- **Docker** or **Podman** with Compose V2
-- **Git**
-- **Bash 5+**
-- **[just](https://github.com/casey/just)** -- command runner
-- **[distrobox](https://distrobox.it/)** (recommended) -- dev toolchain container
-
-`just setup::deps` will detect your distro and install what's missing (except `just` itself). `setup::init` only needs to run once; re-run `just setup::reconfigure` to change your feature/SSH/editor choices later — it re-clones for newly-selected features and prunes deselected ones (in-tree clones move to `.backups/`, never deleted).
-
-### Dev environment (distrobox)
-
-All dev tools (Lua 5.1, [Lux](https://github.com/lumen-oss/lux), Node.js, Cargo, clangd, StyLua) are defined in [`docker/dev.Containerfile`](docker/dev.Containerfile). This file is the canonical manifest of system dependencies.
-
-Running `just setup::init` will offer to build the image and create a distrobox for you. Recipes that need these tools (`bar::lint`, `bar::fmt`, `bar::units`, `lua::library`, etc.) automatically enter the distrobox when `DEVTOOLS_DISTROBOX` is set in `.env`.
-
-To set up a new distrobox standalone:
-
-```bash
-just setup::distrobox
-```
-
-### Editor integration
-
-`setup::init` wires up your editor automatically if you say yes at the Step 0/N prompt — language servers and formatters get exported from the distrobox to `~/.local/bin`, and `compile_commands.json` is generated against RecoilEngine for clangd. To re-run it standalone (if you skipped during init, or want to refresh after a Containerfile change):
-
-```bash
-just setup::editor
-```
-
-Exports `emmylua_ls`, `emmylua_check`, `clangd`, `stylua`, and `lx` as wrapper scripts in `~/.local/bin` (via `distrobox-export`). Your editor finds the wrappers on PATH and everything works as if installed natively.
-
-**Recommended extensions:**
-
-* [EmmyLua](https://marketplace.visualstudio.com/items?itemName=tangzx.emmylua) (Lua language server -- Cursor users: install from VSIX, the marketplace version is outdated)
-* [StyLua](https://marketplace.visualstudio.com/items?itemName=JohnnyMorganz.stylua) (Lua formatter)
-* [clangd](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd) (C/C++ for engine work)
-
-`just setup::editor` writes a workspace `.vscode/settings.json` into the BAR
-repo (gitignored, per-checkout) that configures `JohnnyMorganz.stylua` as the
-Lua formatter. Both VS Code and Cursor read this automatically. If the file
-already exists, setup shows a diff against the recommended defaults and
-leaves yours intact. Run `just bar::fmt` to format manually.
-
-#### VS Code Test Switcher (optional)
-
-The [test-switcher](https://marketplace.visualstudio.com/items?itemName=bmalehorn.test-switcher) plugin lets you jump between BAR test and source files with `Cmd+Shift+Y` / `Ctrl+Shift+Y`. Add this to your User Settings (JSON):
+The [test-switcher](https://marketplace.visualstudio.com/items?itemName=bmalehorn.test-switcher) plugin jumps between BAR test and source files with `Cmd+Shift+Y` / `Ctrl+Shift+Y`. Add to your User Settings (JSON):
 
 ```json
 "test-switcher.rules": [
@@ -153,34 +109,43 @@ The [test-switcher](https://marketplace.visualstudio.com/items?itemName=bmalehor
 ]
 ```
 
-#### IntelliJ IDEA
+</details>
 
-`setup::editor` exports the toolchain but does not configure IntelliJ — the auto-written `.vscode/settings.json` is VS Code only. Two manual steps cover the equivalent:
+<details>
+<summary><strong>Pre-commit hook (stylua + luacheck)</strong></summary>
 
-* **Lua** — install the **EmmyLua** plugin from the JetBrains Marketplace (the analog of the EmmyLua extension above).
-* **Formatting** — to match the stylua format-on-save that VS Code users get from `.vscode/settings.json`, add a **File Watcher** (*Settings → Tools → File Watchers*) on Lua files: set **Program** to the *absolute* path of `~/.local/bin/stylua` (a GUI-launched IDE does not inherit your shell `PATH`) and **Arguments** to `$FilePath$`.
+`just setup::hooks` installs a git pre-commit hook that runs stylua and luacheck on staged Lua before each commit.
 
-If JetBrains use spreads, `setup::editor` could generate an `.idea/watcherTasks.xml` for this the way it already writes `.vscode/settings.json`.
+</details>
 
-### Git hooks
+## Using Your Own Forks
 
-Install a pre-commit hook that runs `stylua` (formatting) and `luacheck` (linting) on every commit:
+`repos.conf` lists the default upstream repositories. To override any with your own fork or branch, copy it to `repos.local.conf` (gitignored — won't affect anyone else), keep only the entries you want to change, and re-clone:
 
 ```bash
-just setup::hooks
+cp repos.conf repos.local.conf
+# edit repos.local.conf, then:
+just repos::clone teiserver
 ```
 
-### Windows (WSL2)
+Both files share one whitespace-delimited format:
 
-See [Quick Setup (Windows)](#quick-setup-windows) for the full WSL2 install flow. Everything -- services, testing, formatting, engine IDE integration -- works unchanged inside WSL2; the engine itself runs as a native Windows process for performance (see [Launching from WSL2](#launching-from-wsl2)). The `dev.Containerfile` documents every dependency; if you prefer native Windows (MSYS2/mingw), use it as a reference.
+```
+# directory    url    branch    feature    [local_path]
+teiserver  https://github.com/yourname/teiserver.git  your-branch  teiserver
+bar-lobby  https://github.com/yourname/bar-lobby.git  your-branch  bar,chobby
+```
 
-#### Password-manager SSH agent integrations (optional)
+- **directory** -- local folder name (created by `clone`)
+- **url** -- git clone URL
+- **branch** -- branch to checkout
+- **feature** -- comma-separated tags (`bar`, `recoil`, `teiserver`, `chobby`, `spads-source`); a repo is pulled in by any of its tags (e.g. `bar-lobby` serves both `bar` and `chobby`)
+- **local_path** -- (optional) absolute or `~`-relative path to **symlink** instead of clone (e.g. a fifth column `~/code/lua-doc-extractor`)
 
-If you store SSH keys in a password manager and want the agent to live there instead of in `~/.ssh`, the `ssh::` module has per-vendor recipes. Currently implemented:
+Two optional `@`-directives can lead the file:
 
-- **1Password** — `just ssh::op-setup`. Bridges the Windows 1Password agent into WSL via `socat` + `npiperelay`, or points `SSH_AUTH_SOCK` at `~/.1password/agent.sock` on native Linux (incl. Bazzite via Flatpak). Idempotent.
-
-Other managers (Bitwarden, KeePassXC, etc.) can be added under `scripts/ssh/` following the same pattern — see `scripts/ssh/lib.sh` for the shared helpers (`bashrc_apply`, `detect_env`, `pause`).
+- `@protocol ssh` -- rewrite every `https://github.com/…` entry to its `git@github.com:…` form (or `@protocol https` for the reverse), so you don't hand-edit each URL for SSH.
+- `@local_root ~/code` -- resolve any entry without a `local_path` to a symlink at `<root>/<directory>` instead of cloning -- for when you keep all the repos as siblings.
 
 ## Common Workflows
 
@@ -237,36 +202,30 @@ just bar::launch --no-gui --play bar --source local --map "Quicksilver"
 just bar::launch --print-cmd --play bar --source latest
 ```
 
-`--source local` requires the relevant `link::create` to have run; `--source latest` resolves to `rapid://...:test` and downloads on demand.
+<details>
+<summary><strong>Booting via the AppImage launcher (Linux)</strong></summary>
 
-The launcher boots the engine directly by default. To go through the AppImage launcher (handles splash + auto-update, mirrors how real users start the game), pass `--boot launcher` and point us at the AppImage:
+By default the launcher boots the engine directly. Pass `--boot launcher` to go through the AppImage launcher instead (splash + auto-update, like a real install) and point at the AppImage:
 
 ```bash
 export BAR_APPIMAGE_PATH=~/Applications/Beyond-All-Reason.AppImage
 just bar::launch --no-gui --play chobby --source latest --boot launcher
 ```
 
-`~/Applications/` is [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher)'s canonical install path. Any AppImage matching `beyond-all-reason*.AppImage` (case-insensitive) is auto-discovered if `BAR_APPIMAGE_PATH` points at a directory.
+`~/Applications/` is [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher)'s canonical path; any `beyond-all-reason*.AppImage` there is auto-discovered when `BAR_APPIMAGE_PATH` points at a directory.
 
-`just setup::init` runs `pipx install --editable` against the bar_debug_launcher checkout, so its `pyproject.toml` is the single source of truth for deps and edits to the launcher source reflect live. If you skipped that step, `just bar::launch` will tell you to run setup. The GUI imports `tkinter` -- on a pyenv install built without tk-devel, install your distro's tk package (`python3-tkinter` on Fedora, `python3-tk` on Debian, `tk` on Arch) and rebuild Python.
+</details>
 
 #### Launching from WSL2
 
-On WSL2 the engine has to run as a native Windows process for usable performance (WSLg / Plan9 game-load measured ~7m30s vs ~24s native), so `just bar::launch` looks different:
+On WSL2 the engine runs as a native Windows process (WSLg is far too slow for the game), so `just bar::launch` routes through Windows: `setup::init` does the one-time wiring (it prompts for a `BAR_DATA_DIR` -- the Windows-side data dir the engine reads from), and each launch cold-copies your checkouts onto NTFS before starting the engine there.
 
-1. `just setup::init` (on WSL) prompts for a `BAR_DATA_DIR` -- the spring data directory the engine reads from (default: the BAR launcher's own data dir, `%LOCALAPPDATA%\Programs\Beyond-All-Reason\data`). Persisted to `.env`.
-2. Setup also installs Python on Windows via winget (if missing), creates a venv at `%BAR_DATA_DIR%\.venv`, installs `bar_debug_launcher` into it, and writes a `bin\bar-launch.cmd` shim with absolute paths baked in.
-3. `just bar::launch` then: cold-copies `Beyond-All-Reason/` and `BYAR-Chobby/` (and the engine if built) from WSL ext4 onto NTFS (`%BAR_DATA_DIR%\games\...`, `engine\local-build\`); shells out to `cmd.exe /c bar-launch.cmd <flags>`. `just engine::build windows` cold-copies the rebuilt engine artifacts the same way.
-
-The cold copy uses inplace writes (no inode rotation) so engine mmaps stay valid if you re-launch quickly. We previously ran a `\\wsl.localhost\` watchdog watcher for live edit propagation, but `ReadDirectoryChangesW` over Plan 9 doesn't receive Linux-side inotify events; the watcher logged zero mirrored events in practice. Cold-copy at known sync points (launch, build) replaced it.
+That copy only happens at launch and `engine::build windows` -- there's **no live edit propagation**, so re-sync to pick up Lua/source edits:
 
 ```bash
-just bar::sync                 # cold-copy sources without launching
-just bar::sync-logs -- -f      # tail the cold-copy log
-just bar::regen-shim           # rewrite bar-launch.cmd if BAR_DATA_DIR changes
+just bar::sync         # cold-copy sources without launching
+just bar::sync-logs    # tail the cold-copy log
 ```
-
-If `cmd.exe`, `wslpath`, or `winget.exe` aren't reachable from WSL, the relevant setup steps no-op with a warning -- you can edit `BAR-Devtools/.env` directly and re-run `just setup::init` once the prereqs are in place.
 
 ### Documentation
 
@@ -285,90 +244,22 @@ just services::logs teiserver   # tail logs
 just services::shell teiserver  # open bash inside the running container
 ```
 
-## Using Your Own Forks
+## Requirements
 
-`repos.conf` lists the default upstream repositories. To use your own forks or work on specific branches:
+- **Linux** (Arch, Debian/Ubuntu, Fedora) -- or **Windows** via WSL2 (see below)
+- **Docker** or **Podman** with Compose V2
+- **Git**
+- **Bash 5+**
+- **[just](https://github.com/casey/just)** -- command runner
+- **[distrobox](https://distrobox.it/)** (recommended) -- dev toolchain container
 
-```bash
-cp repos.conf repos.local.conf
-```
+`just setup::deps` will detect your distro and install what's missing (except `just` itself). `setup::init` only needs to run once; re-run `just setup::reconfigure` to change your feature/SSH/editor choices later — it re-clones for newly-selected features and prunes deselected ones (in-tree clones move to `.backups/`, never deleted).
 
-Edit `repos.local.conf` -- only include the repos you want to override:
+### Dev environment (distrobox)
 
-```
-teiserver  https://github.com/yourname/teiserver.git  your-branch  teiserver
-bar-lobby  https://github.com/yourname/bar-lobby.git  your-branch  bar,chobby
-```
-
-Then clone or re-clone:
-
-```bash
-just repos::clone teiserver
-```
-
-`repos.local.conf` is gitignored so it won't affect anyone else.
-
-### Local paths
-
-You can also point a repo entry at a local directory instead of cloning. Add a fifth column with the path:
-
-```
-lua-doc-extractor  https://github.com/rhys-vdw/lua-doc-extractor.git  your-branch  recoil  ~/code/lua-doc-extractor
-```
-
-This creates a symlink instead of cloning.
-
-## Repository Config Format
-
-`repos.conf` uses a simple whitespace-delimited format:
-
-```
-# directory    url    branch    feature    [local_path]
-teiserver      https://github.com/beyond-all-reason/teiserver.git    master    teiserver
-bar-lobby      https://github.com/beyond-all-reason/bar-lobby.git    master    bar,chobby
-```
-
-- **directory** -- local folder name (created by `clone`)
-- **url** -- git clone URL
-- **branch** -- branch to checkout
-- **feature** -- comma-separated feature tags. Valid tags: `bar`, `recoil`, `teiserver`, `chobby`, `spads-source`. A repo with multiple tags is pulled in by any of those features (e.g. `bar-lobby` is needed for both `bar` and `chobby`).
-- **local_path** -- (optional) absolute or `~`-relative path to symlink instead of cloning
+All dev tools (Lua 5.1, [Lux](https://github.com/lumen-oss/lux), Node.js, Cargo, clangd, StyLua) live in [`docker/dev.Containerfile`](docker/dev.Containerfile), the canonical dependency manifest. `setup::init` builds it; recipes that need these tools (`bar::lint`, `bar::fmt`, `bar::units`, …) auto-enter the distrobox. Rebuild standalone with `just setup::distrobox`.
 
 ## Architecture
-
-```
-BAR-Devtools/
-├── Justfile                         # Root command runner (lists all modules)
-├── just/
-│   ├── services.just                # Docker Compose service management
-│   ├── repos.just                   # Git repository operations
-│   ├── engine.just                  # RecoilEngine build
-│   ├── setup.just                   # First-time setup & dependency install
-│   ├── link.just                    # Game directory symlinking
-│   ├── lua.just                     # lua-doc-extractor & Lua library generation
-│   ├── docs.just                    # Hugo documentation server
-│   ├── bar.just                     # BAR Lua testing, linting & formatting
-│   └── tei.just                     # Teiserver mix tests
-├── scripts/
-│   ├── common.sh                    # Shared color/logging helpers
-│   ├── repos.sh                     # repos.conf parsing & git operations
-│   └── setup.sh                     # Distro detection, deps, prerequisite checks
-├── repos.conf                       # Repository sources & branches
-├── docker-compose.dev.yml           # Service definitions
-├── docker/
-│   ├── teiserver.dev.Dockerfile     # Teiserver dev image (Elixir + Phoenix)
-│   ├── teiserver-entrypoint.sh      # DB init, seeding, migrations
-│   ├── teiserver.dockerignore       # Build context optimization
-│   ├── dev.Containerfile             # Distrobox dev environment (Lua 5.1, lux, node, cargo, clangd)
-│   ├── setup-spads-bot.exs          # Creates SPADS bot account in Teiserver
-│   ├── spads-dev-entrypoint.sh      # SPADS startup + game data download
-│   └── spads_dev.conf               # Simplified SPADS config for dev
-├── teiserver/                       # ← cloned by just repos::clone (gitignored)
-├── bar-lobby/                       # ← cloned (gitignored)
-├── Beyond-All-Reason/               # ← cloned (gitignored)
-├── RecoilEngine/                    # ← cloned (gitignored)
-└── spads_config_bar/                # ← cloned (gitignored)
-```
 
 ### What the Docker stack does
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ On WSL, `setup::init` additionally prompts for a `BAR_DATA_DIR` and wires up the
 Optional — none of this is needed to build or run BAR.
 
 <details>
-<summary><strong>A nicer shell prompt (starship)</strong></summary>
+<summary><strong>A more beautiful shell prompt (starship)</strong></summary>
 
 A fresh WSL distro drops you at a barebones `user@host:~$` — no git info, exit status, or color. [starship](https://starship.rs/) fixes that. Install it into `~/.local/bin` on the host (Linux or WSL):
 
@@ -79,7 +79,7 @@ time_format = '%T'
 style = 'bold yellow'
 ```
 
-Starship's defaults use Nerd Font glyphs, which render as boxes without one installed — either install a Nerd Font (Windows: the `winget` line in [Quick Setup (Windows)](#quick-setup-windows); Linux: your distro's nerd-fonts package) or strip them: `starship preset plain-text-symbols -o ~/.config/starship.toml`.
+Starship's defaults use Nerd Font glyphs. In the Windows terminal — including WSL, which renders through it — they show as boxes until you install a Nerd Font: use the `winget` line in [Quick Setup (Windows)](#quick-setup-windows), or strip the glyphs with `starship preset plain-text-symbols -o ~/.config/starship.toml`. Native Linux terminals usually have a capable font already.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -67,18 +67,6 @@ echo 'eval "$(starship init bash)"' >> ~/.bashrc && exec bash
 
 Targeting `~/.local/bin` — rather than the installer's default `/usr/local/bin`, or a distro package's `/usr/bin` — is what makes the prompt follow you into the dev container: distrobox shares your home dir and `~/.bashrc`, not host system dirs, so `distrobox enter bar-dev` picks up the same binary and init line for free.
 
-A minimal `~/.config/starship.toml` that adds a clock on the right:
-
-```toml
-right_format = '$time'
-
-[time]
-disabled = false
-format = '[$time]($style)'
-time_format = '%T'
-style = 'bold yellow'
-```
-
 Starship's defaults use Nerd Font glyphs. In the Windows terminal — including WSL, which renders through it — they show as boxes until you install a Nerd Font: use the `winget` line in [Quick Setup (Windows)](#quick-setup-windows), or strip the glyphs with `starship preset plain-text-symbols -o ~/.config/starship.toml`. Native Linux terminals usually have a capable font already.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -16,40 +16,15 @@ just setup::init                  # full first-time setup (clones, builds, edito
 just services::up                 # start Postgres + Teiserver
 ```
 
-`setup::init` front-loads every interactive question (features, SSH choice, springsettings opt-in, editor integration) into one batch at the top, then runs unattended. If you opt in to editor integration during the prompt, the language servers / formatters are wired up at the end of init — you don't run a second command.
-
-`scripts/bootstrap.sh` exists because `apt install just` on Ubuntu LTS produces 1.21 (frozen), which can't parse this repo's module syntax. The script wraps the upstream installer at <https://just.systems> and is idempotent — safe to re-run. If you'd rather not pipe a script, the equivalent is:
-
-```bash
-curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
-  | bash -s -- --to ~/.local/bin
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
-```
-
-`setup::init` walks you through installing dependencies, cloning repositories, and building Docker images. You only need to run it once.
-
-To revisit those choices later -- change which features you work on, redo the SSH or editor setup -- run `just setup::reconfigure`. It re-prompts every saved `.env` decision, then re-clones for newly-selected features and prunes deselected ones (workspace symlinks are removed; in-tree clones are moved to `.backups/`, never deleted). Under the hood it just re-runs `setup::init` with the `BAR_RESET_CONFIG=1` environment variable, which forces each setup module to ask again instead of reusing `.env`.
-
-`services::up` starts PostgreSQL and Teiserver. On first run it seeds the database with test data and creates default accounts (~2-3 minutes). Subsequent starts are fast.
-
-Once running:
-
-| Service | URL |
-|---------|-----|
-| Teiserver Web UI | http://localhost:4000 |
-| Teiserver HTTPS | https://localhost:8888 |
-| Spring Protocol | `localhost:8200` (TCP) / `:8201` (TLS) |
-| PostgreSQL | `localhost:5433` |
-
-**Default login:** `root@localhost` / `password`
+Teiserver comes up at http://localhost:4000 — log in with `root@localhost` / `password`. (Full port list under [Ports](#ports).)
 
 ## Quick Setup (Windows)
 
-The whole stack runs inside WSL2 — nothing needs native Windows. From a **PowerShell** prompt, install the VS Code WSL bridge, a Nerd Font (for a decent prompt later), cap WSL2's resource use, and pull a distro:
+The whole stack runs inside WSL2 — nothing needs native Windows. From a **PowerShell** prompt, install the VS Code WSL bridge, cap WSL2's resource use, and pull a distro:
 
 ```powershell
 code --install-extension ms-vscode-remote.remote-wsl
-winget install --id DEVCOM.JetBrainsMonoNerdFont
+winget install --id DEVCOM.JetBrainsMonoNerdFont   # optional — Nerd Font for the starship prompt (see Nice-to-haves)
 
 # Leave ~5-6 GB for Windows; tune to your machine:
 @"
@@ -62,7 +37,7 @@ processors=4
 wsl --install -d Ubuntu-24.04
 ```
 
-In **Windows Terminal**, set Ubuntu as your default profile and pick *JetBrainsMono Nerd Font* under that profile's *Appearance → Font face*. Open a fresh Ubuntu terminal and follow the [Linux Quick Start](#quick-start) — it's identical:
+In **Windows Terminal**, set Ubuntu as your default profile (and, if you installed the Nerd Font above, pick *JetBrainsMono Nerd Font* under that profile's *Appearance → Font face*). Open a fresh Ubuntu terminal and follow the [Linux Quick Start](#quick-start) — it's identical:
 
 ```bash
 git clone https://github.com/beyond-all-reason/BAR-Devtools.git
@@ -82,7 +57,7 @@ On WSL, `setup::init` additionally prompts for a `BAR_DATA_DIR` and wires up the
 **A prompt that doesn't make you sad.** A fresh WSL distro's bash prompt (`user@host:~$`) has no git info, exit status, or color. Install [starship](https://starship.rs/) on the host:
 
 ```bash
-curl -sS https://starship.rs/install.sh | sh
+curl -sS https://starship.rs/install.sh | sh -s -- -b ~/.local/bin
 echo 'eval "$(starship init bash)"' >> ~/.bashrc && exec bash
 ```
 
@@ -98,16 +73,6 @@ time_format = '%T'
 style = 'bold yellow'
 ```
 
-The dev distrobox image (`docker/dev.Containerfile`) already ships starship pre-enabled, so `distrobox enter bar-dev` gives you the prompt with zero host setup. Starship's defaults use Nerd Font glyphs — if you skipped the font install above, strip them with `starship preset plain-text-symbols -o ~/.config/starship.toml`.
-
-**Git identity + Claude Code.**
-
-```bash
-git config --global user.email "you@example.com"
-git config --global user.name "Your Name"
-curl -fsSL https://claude.ai/install.sh | bash
-```
-
 </details>
 
 ## Requirements
@@ -119,7 +84,7 @@ curl -fsSL https://claude.ai/install.sh | bash
 - **[just](https://github.com/casey/just)** -- command runner
 - **[distrobox](https://distrobox.it/)** (recommended) -- dev toolchain container
 
-`just setup::deps` will detect your distro and install what's missing (except `just` itself).
+`just setup::deps` will detect your distro and install what's missing (except `just` itself). `setup::init` only needs to run once; re-run `just setup::reconfigure` to change your feature/SSH/editor choices later — it re-clones for newly-selected features and prunes deselected ones (in-tree clones move to `.backups/`, never deleted).
 
 ### Dev environment (distrobox)
 

--- a/README.md
+++ b/README.md
@@ -7,23 +7,28 @@ Everything server-side runs in Docker. The game client runs natively.
 ## Quick Start
 
 ```bash
-# Install just
-pacman -S just        # Arch
-dnf install just      # Fedora
-apt install just      # Debian/Ubuntu
-```
-
-```bash
-# Run setup
 git clone https://github.com/beyond-all-reason/BAR-Devtools.git
 cd BAR-Devtools
-just setup::init
-just services::up
-# recommended
-just setup::editor    # export clangd + generate compile_commands.json
+bash scripts/bootstrap.sh         # installs `just` >= 1.31 to ~/.local/bin
+exec "$SHELL" -l                  # reload PATH
+
+just setup::init                  # full first-time setup (clones, builds, editor wiring — all prompts up front)
+just services::up                 # start Postgres + Teiserver
+```
+
+`setup::init` front-loads every interactive question (features, SSH choice, springsettings opt-in, editor integration) into one batch at the top, then runs unattended. If you opt in to editor integration during the prompt, the language servers / formatters are wired up at the end of init — you don't run a second command.
+
+`scripts/bootstrap.sh` exists because `apt install just` on Ubuntu LTS produces 1.21 (frozen), which can't parse this repo's module syntax. The script wraps the upstream installer at <https://just.systems> and is idempotent — safe to re-run. If you'd rather not pipe a script, the equivalent is:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
+  | bash -s -- --to ~/.local/bin
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc && source ~/.bashrc
 ```
 
 `setup::init` walks you through installing dependencies, cloning repositories, and building Docker images. You only need to run it once.
+
+To revisit those choices later -- change which features you work on, redo the SSH or editor setup -- run `just setup::reconfigure`. It re-prompts every saved `.env` decision, then re-clones for newly-selected features and prunes deselected ones (workspace symlinks are removed; in-tree clones are moved to `.backups/`, never deleted). Under the hood it just re-runs `setup::init` with the `BAR_RESET_CONFIG=1` environment variable, which forces each setup module to ask again instead of reusing `.env`.
 
 `services::up` starts PostgreSQL and Teiserver. On first run it seeds the database with test data and creates default accounts (~2-3 minutes). Subsequent starts are fast.
 
@@ -37,6 +42,73 @@ Once running:
 | PostgreSQL | `localhost:5433` |
 
 **Default login:** `root@localhost` / `password`
+
+## Quick Setup (Windows)
+
+The whole stack runs inside WSL2 — nothing needs native Windows. From a **PowerShell** prompt, install the VS Code WSL bridge, a Nerd Font (for a decent prompt later), cap WSL2's resource use, and pull a distro:
+
+```powershell
+code --install-extension ms-vscode-remote.remote-wsl
+winget install --id DEVCOM.JetBrainsMonoNerdFont
+
+# Leave ~5-6 GB for Windows; tune to your machine:
+@"
+[wsl2]
+memory=12GB
+swap=8GB
+processors=4
+"@ | Set-Content $env:USERPROFILE\.wslconfig
+
+wsl --install -d Ubuntu-24.04
+```
+
+In **Windows Terminal**, set Ubuntu as your default profile and pick *JetBrainsMono Nerd Font* under that profile's *Appearance → Font face*. Open a fresh Ubuntu terminal and follow the [Linux Quick Start](#quick-start) — it's identical:
+
+```bash
+git clone https://github.com/beyond-all-reason/BAR-Devtools.git
+cd BAR-Devtools
+bash scripts/bootstrap.sh
+exec "$SHELL" -l
+
+just setup::init
+just services::up
+```
+
+On WSL, `setup::init` additionally prompts for a `BAR_DATA_DIR` and wires up the native-Windows launch path — the engine runs as a Windows process for performance. See [Launching from WSL2](#launching-from-wsl2) for how `just bar::launch` crosses the WSL/Windows boundary.
+
+<details>
+<summary><strong>Nice-to-haves (optional)</strong></summary>
+
+**A prompt that doesn't make you sad.** A fresh WSL distro's bash prompt (`user@host:~$`) has no git info, exit status, or color. Install [starship](https://starship.rs/) on the host:
+
+```bash
+curl -sS https://starship.rs/install.sh | sh
+echo 'eval "$(starship init bash)"' >> ~/.bashrc && exec bash
+```
+
+A minimal `~/.config/starship.toml` that adds a clock on the right:
+
+```toml
+right_format = '$time'
+
+[time]
+disabled = false
+format = '[$time]($style)'
+time_format = '%T'
+style = 'bold yellow'
+```
+
+The dev distrobox image (`docker/dev.Containerfile`) already ships starship pre-enabled, so `distrobox enter bar-dev` gives you the prompt with zero host setup. Starship's defaults use Nerd Font glyphs — if you skipped the font install above, strip them with `starship preset plain-text-symbols -o ~/.config/starship.toml`.
+
+**Git identity + Claude Code.**
+
+```bash
+git config --global user.email "you@example.com"
+git config --global user.name "Your Name"
+curl -fsSL https://claude.ai/install.sh | bash
+```
+
+</details>
 
 ## Requirements
 
@@ -61,23 +133,15 @@ To set up a new distrobox standalone:
 just setup::distrobox
 ```
 
-### Editor integration (VS Code / Cursor)
+### Editor integration
 
-Language servers and formatters live inside the distrobox. One command exports them to your host and generates `compile_commands.json` for engine C++ support:
+`setup::init` wires up your editor automatically if you say yes at the Step 0/N prompt — language servers and formatters get exported from the distrobox to `~/.local/bin`, and `compile_commands.json` is generated against RecoilEngine for clangd. To re-run it standalone (if you skipped during init, or want to refresh after a Containerfile change):
 
 ```bash
 just setup::editor
 ```
 
-This exports `emmylua_ls`, `clangd`, and `stylua` as wrapper scripts in `~/.local/bin` (via `distrobox-export`), and runs `cmake` against RecoilEngine to produce `compile_commands.json` for clangd. Your editor finds the wrappers on PATH and everything works as if installed natively.
-
-### Git hooks
-
-Install a pre-commit hook that runs `stylua` (formatting) and `luacheck` (linting) on every commit:
-
-```bash
-just setup::hooks
-```
+Exports `emmylua_ls`, `emmylua_check`, `clangd`, `stylua`, and `lx` as wrapper scripts in `~/.local/bin` (via `distrobox-export`). Your editor finds the wrappers on PATH and everything works as if installed natively.
 
 **Recommended extensions:**
 
@@ -85,17 +149,11 @@ just setup::hooks
 * [StyLua](https://marketplace.visualstudio.com/items?itemName=JohnnyMorganz.stylua) (Lua formatter)
 * [clangd](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd) (C/C++ for engine work)
 
-**Settings** (JSON):
-
-```json
-{
-  "emmylua.ls.executablePath": "~/.local/bin/emmylua_ls",
-  "[lua]": {
-    "editor.defaultFormatter": "JohnnyMorganz.stylua",
-    "editor.formatOnSave": true
-  }
-}
-```
+`just setup::editor` writes a workspace `.vscode/settings.json` into the BAR
+repo (gitignored, per-checkout) that configures `JohnnyMorganz.stylua` as the
+Lua formatter. Both VS Code and Cursor read this automatically. If the file
+already exists, setup shows a diff against the recommended defaults and
+leaves yours intact. Run `just bar::fmt` to format manually.
 
 #### VS Code Test Switcher (optional)
 
@@ -122,16 +180,34 @@ The [test-switcher](https://marketplace.visualstudio.com/items?itemName=bmalehor
 ]
 ```
 
-### Windows (WSL2)
+#### IntelliJ IDEA
 
-Install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install), then inside your WSL distro install podman and follow the Linux instructions above:
+`setup::editor` exports the toolchain but does not configure IntelliJ — the auto-written `.vscode/settings.json` is VS Code only. Two manual steps cover the equivalent:
+
+* **Lua** — install the **EmmyLua** plugin from the JetBrains Marketplace (the analog of the EmmyLua extension above).
+* **Formatting** — to match the stylua format-on-save that VS Code users get from `.vscode/settings.json`, add a **File Watcher** (*Settings → Tools → File Watchers*) on Lua files: set **Program** to the *absolute* path of `~/.local/bin/stylua` (a GUI-launched IDE does not inherit your shell `PATH`) and **Arguments** to `$FilePath$`.
+
+If JetBrains use spreads, `setup::editor` could generate an `.idea/watcherTasks.xml` for this the way it already writes `.vscode/settings.json`.
+
+### Git hooks
+
+Install a pre-commit hook that runs `stylua` (formatting) and `luacheck` (linting) on every commit:
 
 ```bash
-# Inside WSL (Ubuntu)
-sudo apt install -y podman distrobox
+just setup::hooks
 ```
 
-Everything -- services, testing, formatting, engine IDE integration -- works unchanged inside WSL2. The `dev.Containerfile` documents every dependency; if you prefer native Windows (MSYS2/mingw), use it as a reference.
+### Windows (WSL2)
+
+See [Quick Setup (Windows)](#quick-setup-windows) for the full WSL2 install flow. Everything -- services, testing, formatting, engine IDE integration -- works unchanged inside WSL2; the engine itself runs as a native Windows process for performance (see [Launching from WSL2](#launching-from-wsl2)). The `dev.Containerfile` documents every dependency; if you prefer native Windows (MSYS2/mingw), use it as a reference.
+
+#### Password-manager SSH agent integrations (optional)
+
+If you store SSH keys in a password manager and want the agent to live there instead of in `~/.ssh`, the `ssh::` module has per-vendor recipes. Currently implemented:
+
+- **1Password** — `just ssh::op-setup`. Bridges the Windows 1Password agent into WSL via `socat` + `npiperelay`, or points `SSH_AUTH_SOCK` at `~/.1password/agent.sock` on native Linux (incl. Bazzite via Flatpak). Idempotent.
+
+Other managers (Bitwarden, KeePassXC, etc.) can be added under `scripts/ssh/` following the same pattern — see `scripts/ssh/lib.sh` for the shared helpers (`bashrc_apply`, `detect_env`, `pause`).
 
 ## Common Workflows
 
@@ -143,9 +219,11 @@ Run `just` with no arguments for the full recipe list.
 just bar::fmt           # format with stylua
 just bar::lint          # lint with luacheck
 just bar::units         # run busted unit tests
-just bar::test-shell    # interactive busted shell,
+just bar::units-shell   # interactive busted shell,
                         #   run `busted -t focus` to test specs tagged "#focus"
                         #   for example: `it "should do something #focus", function()`
+just bar::lx-shell      # interactive lx shell for package work
+                        #   (`lx add <pkg>`, `lx sync`, `lx install`, etc.)
 ```
 
 ### Teiserver development
@@ -162,12 +240,60 @@ just tei::test-shell            # interactive bash shell with MIX_ENV=test
 
 If you've pulled new teiserver code with migrations, re-run `just tei::setup-test-db` to apply them.
 
+`services::up` mounts `teiserver/lib` and `teiserver/assets` into the running
+container, so editing the web UI (controllers, LiveViews, templates, CSS) takes
+effect live -- Phoenix recompiles and the browser at http://localhost:4000
+refreshes on save, no rebuild or restart. Changes to `mix.exs`, `config/`, or
+deps still need `just services::build` (or `services::up`, which rebuilds).
+
 ### Engine development
 
 ```bash
 just engine::build linux        # build Recoil via docker-build-v2
 just link::create engine        # symlink into game directory
 ```
+
+### Launching the game (dev mode)
+
+`just bar::launch` hands off to [bar_debug_launcher](https://github.com/beyond-all-reason/bar_debug_launcher) with your local `Beyond-All-Reason/`, `BYAR-Chobby/`, and `RecoilEngine/` checkouts wired in via `just link::create`. The Tk GUI opens by default; pass flags for headless use:
+
+```bash
+just bar::launch                                      # GUI
+just bar::launch --no-gui --play chobby --source local
+just bar::launch --no-gui --play bar --source local --map "Quicksilver"
+just bar::launch --print-cmd --play bar --source latest
+```
+
+`--source local` requires the relevant `link::create` to have run; `--source latest` resolves to `rapid://...:test` and downloads on demand.
+
+The launcher boots the engine directly by default. To go through the AppImage launcher (handles splash + auto-update, mirrors how real users start the game), pass `--boot launcher` and point us at the AppImage:
+
+```bash
+export BAR_APPIMAGE_PATH=~/Applications/Beyond-All-Reason.AppImage
+just bar::launch --no-gui --play chobby --source latest --boot launcher
+```
+
+`~/Applications/` is [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher)'s canonical install path. Any AppImage matching `beyond-all-reason*.AppImage` (case-insensitive) is auto-discovered if `BAR_APPIMAGE_PATH` points at a directory.
+
+`just setup::init` runs `pipx install --editable` against the bar_debug_launcher checkout, so its `pyproject.toml` is the single source of truth for deps and edits to the launcher source reflect live. If you skipped that step, `just bar::launch` will tell you to run setup. The GUI imports `tkinter` -- on a pyenv install built without tk-devel, install your distro's tk package (`python3-tkinter` on Fedora, `python3-tk` on Debian, `tk` on Arch) and rebuild Python.
+
+#### Launching from WSL2
+
+On WSL2 the engine has to run as a native Windows process for usable performance (WSLg / Plan9 game-load measured ~7m30s vs ~24s native), so `just bar::launch` looks different:
+
+1. `just setup::init` (on WSL) prompts for a `BAR_DATA_DIR` -- the spring data directory the engine reads from (default: the BAR launcher's own data dir, `%LOCALAPPDATA%\Programs\Beyond-All-Reason\data`). Persisted to `.env`.
+2. Setup also installs Python on Windows via winget (if missing), creates a venv at `%BAR_DATA_DIR%\.venv`, installs `bar_debug_launcher` into it, and writes a `bin\bar-launch.cmd` shim with absolute paths baked in.
+3. `just bar::launch` then: cold-copies `Beyond-All-Reason/` and `BYAR-Chobby/` (and the engine if built) from WSL ext4 onto NTFS (`%BAR_DATA_DIR%\games\...`, `engine\local-build\`); shells out to `cmd.exe /c bar-launch.cmd <flags>`. `just engine::build windows` cold-copies the rebuilt engine artifacts the same way.
+
+The cold copy uses inplace writes (no inode rotation) so engine mmaps stay valid if you re-launch quickly. We previously ran a `\\wsl.localhost\` watchdog watcher for live edit propagation, but `ReadDirectoryChangesW` over Plan 9 doesn't receive Linux-side inotify events; the watcher logged zero mirrored events in practice. Cold-copy at known sync points (launch, build) replaced it.
+
+```bash
+just bar::sync                 # cold-copy sources without launching
+just bar::sync-logs -- -f      # tail the cold-copy log
+just bar::regen-shim           # rewrite bar-launch.cmd if BAR_DATA_DIR changes
+```
+
+If `cmd.exe`, `wslpath`, or `winget.exe` aren't reachable from WSL, the relevant setup steps no-op with a warning -- you can edit `BAR-Devtools/.env` directly and re-run `just setup::init` once the prereqs are in place.
 
 ### Documentation
 
@@ -197,14 +323,14 @@ cp repos.conf repos.local.conf
 Edit `repos.local.conf` -- only include the repos you want to override:
 
 ```
-teiserver  https://github.com/yourname/teiserver.git  your-branch  core
-bar-lobby  https://github.com/yourname/bar-lobby.git  your-branch  core
+teiserver  https://github.com/yourname/teiserver.git  your-branch  teiserver
+bar-lobby  https://github.com/yourname/bar-lobby.git  your-branch  bar,chobby
 ```
 
 Then clone or re-clone:
 
 ```bash
-just repos::clone core
+just repos::clone teiserver
 ```
 
 `repos.local.conf` is gitignored so it won't affect anyone else.
@@ -214,7 +340,7 @@ just repos::clone core
 You can also point a repo entry at a local directory instead of cloning. Add a fifth column with the path:
 
 ```
-lua-doc-extractor  https://github.com/rhys-vdw/lua-doc-extractor.git  your-branch  extra  ~/code/lua-doc-extractor
+lua-doc-extractor  https://github.com/rhys-vdw/lua-doc-extractor.git  your-branch  recoil  ~/code/lua-doc-extractor
 ```
 
 This creates a symlink instead of cloning.
@@ -224,14 +350,15 @@ This creates a symlink instead of cloning.
 `repos.conf` uses a simple whitespace-delimited format:
 
 ```
-# directory    url    branch    group    [local_path]
-teiserver      https://github.com/beyond-all-reason/teiserver.git    master    core
+# directory    url    branch    feature    [local_path]
+teiserver      https://github.com/beyond-all-reason/teiserver.git    master    teiserver
+bar-lobby      https://github.com/beyond-all-reason/bar-lobby.git    master    bar,chobby
 ```
 
 - **directory** -- local folder name (created by `clone`)
 - **url** -- git clone URL
 - **branch** -- branch to checkout
-- **group** -- `core` (required for the dev stack) or `extra` (optional)
+- **feature** -- comma-separated feature tags. Valid tags: `bar`, `recoil`, `teiserver`, `chobby`, `spads-source`. A repo with multiple tags is pulled in by any of those features (e.g. `bar-lobby` is needed for both `bar` and `chobby`).
 - **local_path** -- (optional) absolute or `~`-relative path to symlink instead of cloning
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -51,15 +51,21 @@ just services::up
 
 On WSL, `setup::init` additionally prompts for a `BAR_DATA_DIR` and wires up the native-Windows launch path — the engine runs as a Windows process for performance. See [Launching from WSL2](#launching-from-wsl2) for how `just bar::launch` crosses the WSL/Windows boundary.
 
-<details>
-<summary><strong>Nice-to-haves (optional)</strong></summary>
+## Nice-to-haves
 
-**A prompt that doesn't make you sad.** A fresh WSL distro's bash prompt (`user@host:~$`) has no git info, exit status, or color. Install [starship](https://starship.rs/) on the host:
+Optional — none of this is needed to build or run BAR.
+
+<details>
+<summary><strong>A nicer shell prompt (starship)</strong></summary>
+
+A fresh WSL distro drops you at a barebones `user@host:~$` — no git info, exit status, or color. [starship](https://starship.rs/) fixes that. Install it into `~/.local/bin` on the host (Linux or WSL):
 
 ```bash
 curl -sS https://starship.rs/install.sh | sh -s -- -b ~/.local/bin
 echo 'eval "$(starship init bash)"' >> ~/.bashrc && exec bash
 ```
+
+Targeting `~/.local/bin` — rather than the installer's default `/usr/local/bin`, or a distro package's `/usr/bin` — is what makes the prompt follow you into the dev container: distrobox shares your home dir and `~/.bashrc`, not host system dirs, so `distrobox enter bar-dev` picks up the same binary and init line for free.
 
 A minimal `~/.config/starship.toml` that adds a clock on the right:
 
@@ -72,6 +78,8 @@ format = '[$time]($style)'
 time_format = '%T'
 style = 'bold yellow'
 ```
+
+Starship's defaults use Nerd Font glyphs, which render as boxes without one installed — either install a Nerd Font (Windows: the `winget` line in [Quick Setup (Windows)](#quick-setup-windows); Linux: your distro's nerd-fonts package) or strip them: `starship preset plain-text-symbols -o ~/.config/starship.toml`.
 
 </details>
 

--- a/bar_debug_launcher_config.json
+++ b/bar_debug_launcher_config.json
@@ -1,0 +1,25 @@
+{
+    "title": "Beyond All Reason",
+    "setups": [
+        {
+            "package": {
+                "id": "dev-lobby",
+                "display": "Dev Lobby"
+            },
+            "downloads": {
+                "engines": [
+                    "recoil_2025.06.19"
+                ]
+            },
+            "no_start_script": true,
+            "no_downloads": true,
+            "auto_start": true,
+            "launch": {
+                "start_args": [
+                    "--menu",
+                    "rapid://byar-chobby:test"
+                ]
+            }
+        }
+    ]
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -41,6 +41,11 @@ services:
       - ./docker/teiserver-entrypoint.sh:/entrypoint.sh:ro,z
       - ./docker/setup-spads-bot.exs:/setup-spads-bot.exs:ro,z
       - devtools_state:/app/.devtools
+      # Overlay host source so the live container is the dev env; _build/deps + generated config/priv stay baked in.
+      - ./teiserver/lib:/app/lib:z
+      - ./teiserver/test:/app/test:z
+      - ./teiserver/assets:/app/assets:ro,z
+      - ./teiserver/.formatter.exs:/app/.formatter.exs:ro,z
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:4000/ || exit 1"]
       interval: 10s

--- a/docker-compose.integrations.local.sh
+++ b/docker-compose.integrations.local.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# start.sh for integration tests: prefer /bar/engine/_local, else first stock engine.
+set -e
+
+rm -rf "$1/LuaUI/Config"
+
+if [ -x "$1/engine/_local/spring-headless" ]; then
+    exec "$1/engine/_local/spring-headless" --isolation --write-dir "$1" "$2"
+else
+    engines=("$1"/engine/*/spring-headless)
+    exec "${engines[0]}" --isolation --write-dir "$1" "$2"
+fi

--- a/docker-compose.integrations.local.yml
+++ b/docker-compose.integrations.local.yml
@@ -1,0 +1,6 @@
+services:
+  bar:
+    volumes:
+      # Local Recoil build + start.sh override; vars set by `just bar::integrations`.
+      - ${BAR_LOCAL_ENGINE}:/bar/engine/_local:ro,z
+      - ${BAR_DEVTOOLS_DIR}/docker-compose.integrations.local.sh:/bar/start.sh:ro,z

--- a/docker/dev.Containerfile
+++ b/docker/dev.Containerfile
@@ -1,7 +1,5 @@
-# BAR development environment — canonical list of system dependencies.
-# Used with distrobox: just setup::distrobox
-# Or as a reference for manual installs on any distro / WSL / macOS (brew).
-FROM registry.fedoraproject.org/fedora:latest
+# BAR development environment — canonical system dependency list.
+FROM registry.fedoraproject.org/fedora:43
 
 RUN dnf install -y --setopt=install_weak_deps=False \
         compat-lua compat-lua-devel readline-devel \
@@ -11,6 +9,7 @@ RUN dnf install -y --setopt=install_weak_deps=False \
         just \
         gcc gcc-c++ make git curl jq unzip binutils \
         gawk \
+        gpgme \
         SDL2-devel DevIL-devel glew-devel openal-soft-devel \
         libvorbis-devel freetype-devel fontconfig-devel \
         libunwind-devel libcurl-devel jsoncpp-devel minizip-devel \
@@ -18,21 +17,25 @@ RUN dnf install -y --setopt=install_weak_deps=False \
     && dnf clean all \
     && ln -s /usr/bin/lua-5.1 /usr/local/bin/lua
 
-ARG LUX_VERSION=latest
-RUN ARCH=$(uname -m) \
-    && case "$ARCH" in x86_64) DEB_ARCH=amd64;; aarch64) DEB_ARCH=arm64;; *) echo "unsupported: $ARCH" >&2; exit 1;; esac \
-    && DEB_URL=$(curl -fsSL "https://api.github.com/repos/lumen-oss/lux/releases/${LUX_VERSION}" \
-       | jq -r --arg arch "$DEB_ARCH" '.assets[] | select(.name | test("_" + $arch + "\\.deb$")) | .browser_download_url') \
-    && curl -fsSL "$DEB_URL" -o /tmp/lux.deb \
-    && cd /tmp && ar x lux.deb \
-    && tar xf data.tar.* -C / \
-    && rm -f /tmp/lux.deb /tmp/data.tar.* /tmp/control.tar.* /tmp/debian-binary
+# cargo-binstall bootstrap (Fedora ships neither it nor a binstall-capable cargo).
+RUN curl -L --proto '=https' --tlsv1.2 -sSf \
+        https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh \
+      | bash
 
-# lux's bundled lua 5.1 lacks dlopen, breaking C modules like luafilesystem.
-# Symlink the system lua-5.1 over it so lx test / lx shell work correctly.
-RUN lx --lua-version 5.1 install-lua \
-    && ln -sf /usr/bin/lua-5.1 /root/.local/share/lux/tree/5.1/.lua/bin/lua
+# Keep in lockstep with .github/workflows/test_unit.yml in the BAR repo.
+ARG LUX_VERSION=0.28.3
+RUN /root/.cargo/bin/cargo-binstall --no-confirm \
+        ${LUX_VERSION:+--version $LUX_VERSION} \
+        --install-path /usr/local/bin \
+        lux-cli \
+    && mv /root/.cargo/bin/cargo-binstall /usr/local/bin/ \
+    && rm -rf /root/.cargo
 
+# No `lx install-lua`: lux uses the system Lua 5.1, which has dlopen so C rocks
+# build and load; install-lua's own Lua lacks dlopen. Mirrors BAR's CI.
+
+# stylua direct, not `lx install`: lux's tool runner only resolves src/ layouts.
+# Track: https://github.com/lumen-oss/lux/issues/953
 ARG STYLUA_VERSION=2.0.2
 RUN ARCH=$(uname -m) \
     && case "$ARCH" in x86_64) PLAT=linux-x86_64;; aarch64) PLAT=linux-aarch64;; esac \
@@ -42,12 +45,16 @@ RUN ARCH=$(uname -m) \
     && chmod +x /usr/local/bin/stylua \
     && rm /tmp/stylua.zip
 
-ARG EMMYLUA_VERSION=latest
+ARG EMMYLUA_VERSION=0.22.0
 RUN ARCH=$(uname -m) \
-    && case "$ARCH" in x86_64) PLAT=linux-x64;; aarch64) PLAT=linux-arm64;; esac \
-    && URL=$(curl -fsSL "https://api.github.com/repos/EmmyLuaLs/emmylua-analyzer-rust/releases/${EMMYLUA_VERSION}" \
-       | jq -r --arg plat "emmylua_ls-${PLAT}.tar.gz" '.assets[] | select(.name == $plat) | .browser_download_url') \
-    && curl -fsSL "$URL" | tar xz -C /usr/local/bin \
-    && chmod +x /usr/local/bin/emmylua_ls
+    && case "$ARCH" in \
+         x86_64)  LS_ASSET="emmylua_ls-linux-x64.tar.gz";              CHECK_ASSET="emmylua_check-linux-x64.tar.gz" ;; \
+         aarch64) LS_ASSET="emmylua_ls-linux-arm64-glibc.2.17.tar.gz"; CHECK_ASSET="emmylua_check-linux-arm64-glibc.2.17.tar.gz" ;; \
+         *) echo "unsupported arch for EmmyLua binaries: $ARCH" >&2; exit 1;; \
+       esac \
+    && BASE="https://github.com/EmmyLuaLs/emmylua-analyzer-rust/releases/download/${EMMYLUA_VERSION}" \
+    && curl -fsSL "$BASE/$LS_ASSET"    | tar xz -C /usr/local/bin \
+    && curl -fsSL "$BASE/$CHECK_ASSET" | tar xz -C /usr/local/bin \
+    && chmod +x /usr/local/bin/emmylua_ls /usr/local/bin/emmylua_check
 
 LABEL com.github.containers.toolbox="true"

--- a/docker/sync.Containerfile
+++ b/docker/sync.Containerfile
@@ -1,0 +1,29 @@
+# bar-sync: WSL-only container for the filesystem mirror daemon.
+# Pinned to fc42: Meta only publishes fc42 watchman RPMs, and they link
+# libdwarf.so.0 which fc43 dropped.
+FROM registry.fedoraproject.org/fedora:42
+
+RUN dnf install -y --setopt=install_weak_deps=False \
+        python3 python3-pip python3-devel \
+        gcc \
+        rsync \
+        inotify-tools \
+        curl jq \
+    && pip3 install --break-system-packages --no-cache-dir pywatchman \
+    && dnf remove -y gcc python3-devel \
+    && dnf clean all
+
+# Keep in lockstep with docker/dev.Containerfile.
+ARG WATCHMAN_VERSION=v2026.05.04.00
+RUN ARCH=$(uname -m) \
+    && [ "$ARCH" = "x86_64" ] \
+       || { echo "Watchman: only x86_64 RPM is published by Meta; got $ARCH" >&2; exit 1; } \
+    && URL=$(curl -fsSL "https://api.github.com/repos/facebook/watchman/releases/tags/${WATCHMAN_VERSION}" \
+       | jq -r '.assets[] | select(.name | test("\\.x86_64\\.rpm$")) | .browser_download_url') \
+    && [ -n "$URL" ] && [ "$URL" != "null" ] \
+       || { echo "Watchman: no x86_64.rpm asset on tag ${WATCHMAN_VERSION}" >&2; exit 1; } \
+    && curl -fsSL "$URL" -o /tmp/watchman.rpm \
+    && dnf install -y /tmp/watchman.rpm \
+    && rm /tmp/watchman.rpm
+
+LABEL com.github.containers.toolbox="true"

--- a/just/bar.just
+++ b/just/bar.just
@@ -2,48 +2,127 @@ set export
 
 DEVTOOLS_DIR        := justfile_directory()
 COMPOSE_FILE        := DEVTOOLS_DIR / "docker-compose.dev.yml"
-COMPOSE             := "docker compose -f " + COMPOSE_FILE
+COMPOSE             := "podman compose -f " + COMPOSE_FILE
 BAR_DIR             := DEVTOOLS_DIR / "Beyond-All-Reason"
-INTEGRATION_COMPOSE := "docker compose -f " + BAR_DIR / "tools" / "headless_testing" / "docker-compose.yml"
-LUALS_VERSION       := "3.17.1"
-LUALS_DIR           := DEVTOOLS_DIR / ".devtools" / "lua-language-server"
-LUALS_BIN           := LUALS_DIR / "bin" / "lua-language-server"
+INTEGRATION_COMPOSE := "podman compose -f " + BAR_DIR / "tools" / "headless_testing" / "docker-compose.yml"
 
 [private]
 require-bar:
     #!/usr/bin/env bash
-    if [ ! -d "{{BAR_DIR}}" ]; then
-        echo "Error: Beyond-All-Reason is not cloned." >&2
-        echo "Run: just repos::clone extra" >&2
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    require_repo bar Beyond-All-Reason "Beyond All Reason"
+
+[private]
+require-emmylua-check:
+    #!/usr/bin/env bash
+    if ! command -v emmylua_check >/dev/null 2>&1; then
+        echo "Error: emmylua_check not on PATH (install in the dev container or from https://github.com/EmmyLuaLs/emmylua-analyzer-rust/releases )." >&2
         exit 1
     fi
 
-[private]
-require-luals:
-    #!/usr/bin/env bash
-    [ -x "{{LUALS_BIN}}" ] && exit 0
-    set -euo pipefail
-    source "$DEVTOOLS_DIR/scripts/common.sh"
-    step "lua-language-server not found, downloading v{{LUALS_VERSION}}..."
-    mkdir -p "{{LUALS_DIR}}"
-    ARCH="$(uname -m)"
-    case "$ARCH" in
-        x86_64)  PLAT="linux-x64" ;;
-        aarch64) PLAT="linux-arm64" ;;
-        *)       err "Unsupported arch: $ARCH"; exit 1 ;;
-    esac
-    curl -fsSL "https://github.com/LuaLS/lua-language-server/releases/download/${LUALS_VERSION}/lua-language-server-${LUALS_VERSION}-${PLAT}.tar.gz" \
-        | tar xz -C "{{LUALS_DIR}}"
-    ok "Downloaded lua-language-server v{{LUALS_VERSION}}"
+# Launch BAR for development (GUI by default; --headless to skip the Tk window)
+launch *FLAGS:
+    @bash "$DEVTOOLS_DIR/scripts/launch.sh" {{FLAGS}}
 
-# Type-check BAR Lua code (LuaLS diagnostics)
-check *args: require-bar require-luals
+# Stop BAR processes and the WSL sync daemon (run before engine::build on WSL)
+stop:
+    @BAR_LAUNCH_MODE=stop bash "$DEVTOOLS_DIR/scripts/launch.sh"
+
+# Switch Chobby to byar-dev so the local .sdd loads (idempotent)
+dev-mode:
     #!/usr/bin/env bash
     set -euo pipefail
     source "$DEVTOOLS_DIR/scripts/common.sh"
-    step "Running LuaLS type check..."
+    source "$DEVTOOLS_DIR/scripts/setup.sh"
+    game_dir="${BAR_DATA_DIR:-$(detect_game_dir 2>/dev/null || true)}"
+    if [ -z "$game_dir" ]; then
+      err "Could not resolve BAR data dir. Set BAR_DATA_DIR or run 'just setup::init' first."
+      exit 1
+    fi
+    write_env_key BAR_CHOBBY_CHANNEL "byar-dev"
+    apply_chobby_channel
+    ensure_devmode_marker "$game_dir"
+    info "Relaunch Chobby (or run 'just bar::launch') to pick up the change."
+
+# Regenerate the Windows-side launcher shim from current .env values (WSL2-only)
+regen-shim:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    source "$DEVTOOLS_DIR/scripts/setup.sh"
+    if ! is_wsl; then
+      err "regen-shim is WSL2-only -- on Linux, 'just bar::launch' runs bar-launch directly."
+      exit 1
+    fi
+    regenerate_bar_launch_cmd_shim
+
+# Tail the WSL sync daemon log (WSL2-only)
+sync-logs *TAIL_FLAGS:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    if ! grep -qi microsoft /proc/version 2>/dev/null; then
+      err "sync-logs is WSL2-only (Linux uses symlinks; nothing to log)."
+      exit 1
+    fi
+    if [ -z "${BAR_DATA_DIR:-}" ]; then
+      err "BAR_DATA_DIR not set. Run 'just setup::init' on WSL2 first."
+      exit 1
+    fi
+    logfile="$BAR_DATA_DIR/.bar-launch/sync.log"
+    if [ ! -f "$logfile" ]; then
+      err "No sync log at $logfile yet -- has 'just bar::launch' or 'sync.sh start' run?"
+      exit 1
+    fi
+    info "Tailing $logfile (Ctrl-C to stop)"
+    set -- {{TAIL_FLAGS}}
+    [ "${1:-}" = "--" ] && shift
+    exec tail -F "$@" "$logfile"
+
+# Tail the engine's infolog from the most recent BAR run
+log *TAIL_FLAGS:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    source "$DEVTOOLS_DIR/scripts/setup.sh"
+    tail_extra=()
+    if is_wsl; then
+      if [ -z "${BAR_DATA_DIR:-}" ]; then
+        err "BAR_DATA_DIR not set. Run 'just setup::init' on WSL2 first."
+        exit 1
+      fi
+      logfile="$BAR_DATA_DIR/infolog.txt"
+      # Plan 9 doesn't forward inotify from Windows writers on /mnt/c; poll instead.
+      tail_extra=(---disable-inotify -s 0.5)
+    else
+      game_dir="$(detect_game_dir 2>/dev/null)" || {
+        err "Game directory not detected. Set BAR_DATA_DIR or run 'just setup::init'."
+        exit 1
+      }
+      logfile="$game_dir/infolog.txt"
+    fi
+    if [ ! -f "$logfile" ]; then
+      err "No infolog at $logfile yet -- has the engine run?"
+      exit 1
+    fi
+    info "Tailing $logfile (Ctrl-C to stop)"
+    set -- {{TAIL_FLAGS}}
+    [ "${1:-}" = "--" ] && shift
+    exec tail -F "${tail_extra[@]}" "$@" "$logfile"
+
+# Alias for `bar::log` (just's `alias` directive doesn't work inside modules)
+logs *TAIL_FLAGS:
+    @just bar::log {{TAIL_FLAGS}}
+
+# Type-check BAR Lua code (EmmyLua analyzer CLI)
+check *args: require-bar require-emmylua-check
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    step "Running emmylua_check (EmmyLua analyzer)..."
     cd "$BAR_DIR"
-    "{{LUALS_BIN}}" --check=. --checklevel=Warning --logpath=/tmp/luals-check {{args}}
+    emmylua_check -c .emmyrc.json . {{args}}
     ok "Type check complete"
 
 # Lint BAR Lua code (luacheck via lux)
@@ -70,28 +149,76 @@ units *args: require-bar
     enter_distrobox
     (cd "$BAR_DIR" && lx --lua-version 5.1 test {{args}})
 
-# Drop into an interactive test shell (busted on PATH)
-test-shell: require-bar
+# Install BAR's Lua dependencies into .lux/ (--clean wipes .lux/ first)
+lux-install *args: require-bar
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    enter_distrobox
+    for arg in {{args}}; do
+        if [ "$arg" = "--clean" ]; then
+            warn "Clearing $BAR_DIR/.lux for a fresh install"
+            rm -rf "$BAR_DIR/.lux"
+        fi
+    done
+    (cd "$BAR_DIR" && lx --lua-version 5.1 sync)
+
+# Drop into an interactive shell with busted on PATH (for unit-test work)
+units-shell: require-bar
     #!/usr/bin/env bash
     set -e
     source "$DEVTOOLS_DIR/scripts/common.sh"
     cd "$BAR_DIR"
-    echo -e "${GREEN}[ok]${NC}    Entering lx test shell (busted is available)."
-    echo -e "${GREEN}[ok]${NC}    Type 'exit' to return."
-    if [ -n "${DEVTOOLS_DISTROBOX:-}" ] && [ -z "${_DEVTOOLS_IN_DISTROBOX:-}" ] && [ ! -f /run/.containerenv ]; then
-        exec script -qec "distrobox enter '${DEVTOOLS_DISTROBOX}' -- lx --lua-version 5.1 shell --test --no-loader" /dev/null
-    fi
-    exec lx --lua-version 5.1 shell --test --no-loader
+    ok "Entering lx test shell (busted on PATH)."
+    echo ""
+    info "Filter to specific tests by tagging their description with #<tag>"
+    info "and running busted with -t <tag>. Example:"
+    echo ""
+    echo -e "  ${DIM}-- in some_spec.lua${NC}"
+    echo -e "  ${CYAN}it(\"computes attack range #focus\", function() ... end)${NC}"
+    echo ""
+    echo -e "  ${DIM}# in this shell${NC}"
+    echo -e "  ${CYAN}busted -t focus${NC}"
+    echo ""
+    info "Type 'exit' to return."
+    echo ""
+    distrobox_exec_interactive lx --lua-version 5.1 shell --test --no-loader
+
+# Drop into an interactive lux shell scoped to BAR's lux.toml (for package work)
+lx-shell: require-bar
+    #!/usr/bin/env bash
+    set -e
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    cd "$BAR_DIR"
+    ok "Entering lx shell (package work)."
+    info "Examples: 'lx add <pkg>', 'lx sync', 'lx install'. Type 'exit' to return."
+    echo ""
+    distrobox_exec_interactive lx --lua-version 5.1 shell --no-loader
 
 # Run headless integration tests (x86-64 only)
 integrations *args: require-bar
     #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    require_host
     if [[ "$(uname -m)" == arm64 ]]; then
         echo "Error: integration tests require an x86-64 host." >&2
         echo "The Spring engine used by headless tests has no arm64 build." >&2
         exit 1
     fi
-    {{INTEGRATION_COMPOSE}} up --build --abort-on-container-exit {{args}}
+
+    # Prefer a local Recoil build over the stock engine download if one exists.
+    compose="{{INTEGRATION_COMPOSE}}"
+    local_engine="$DEVTOOLS_DIR/RecoilEngine/build-amd64-linux/install"
+    if [ -x "$local_engine/spring-headless" ]; then
+        info "Using local engine: $local_engine"
+        export BAR_LOCAL_ENGINE="$local_engine"
+        export BAR_DEVTOOLS_DIR="$DEVTOOLS_DIR"
+        compose="$compose -f $DEVTOOLS_DIR/docker-compose.integrations.local.yml"
+    else
+        info "Using stock engine (build RecoilEngine with 'just engine::build linux' to use your local build)"
+    fi
+    $compose up --build --abort-on-container-exit {{args}}
 
 # Run all BAR tests (unit + integrations)
 test: units integrations
@@ -104,7 +231,7 @@ setup-hooks:
     hook="$BAR_DIR/.git/hooks/pre-commit"
     if [ ! -d "$BAR_DIR/.git" ]; then
         err "BAR repo not found at $BAR_DIR"
-        info "Clone it first: just repos::clone extra"
+        info "Clone it first: just repos::clone bar"
         exit 1
     fi
     mkdir -p "$(dirname "$hook")"

--- a/just/bar.just
+++ b/just/bar.just
@@ -149,18 +149,12 @@ units *args: require-bar
     enter_distrobox
     (cd "$BAR_DIR" && lx --lua-version 5.1 test {{args}})
 
-# Install BAR's Lua dependencies into .lux/ (--clean wipes .lux/ first)
-lux-install *args: require-bar
+# Install BAR's Lua dependencies into .lux/
+lux-install: require-bar
     #!/usr/bin/env bash
     set -euo pipefail
     source "$DEVTOOLS_DIR/scripts/common.sh"
     enter_distrobox
-    for arg in {{args}}; do
-        if [ "$arg" = "--clean" ]; then
-            warn "Clearing $BAR_DIR/.lux for a fresh install"
-            rm -rf "$BAR_DIR/.lux"
-        fi
-    done
     (cd "$BAR_DIR" && lx --lua-version 5.1 sync)
 
 # Drop into an interactive shell with busted on PATH (for unit-test work)

--- a/just/docs.just
+++ b/just/docs.just
@@ -3,27 +3,41 @@ set export
 DEVTOOLS_DIR := justfile_directory()
 RECOIL_DIR   := DEVTOOLS_DIR / "RecoilEngine"
 COMPOSE_FILE := DEVTOOLS_DIR / "docker-compose.dev.yml"
-COMPOSE      := "docker compose -f " + COMPOSE_FILE
+COMPOSE      := "podman compose -f " + COMPOSE_FILE
 
 # Generate Lua API pages (full pipeline: extract -> JSON -> markdown)
 generate:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    require_host
     {{COMPOSE}} run --rm recoil-docs lua_pages
 
 # Generate everything then start Hugo dev server
 server:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    require_host
     {{COMPOSE}} run --rm --service-ports recoil-docs server_full -- --bind 0.0.0.0
 
 # Start Hugo dev server without regenerating
 server-only:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    require_host
     {{COMPOSE}} run --rm --service-ports recoil-docs server -- --bind 0.0.0.0
 
 # Rebuild the docs container image
 build:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    require_host
     {{COMPOSE}} build recoil-docs
 
-#   TODO: Same workaround as lua::reset. doc/site/data/* are pipeline outputs tracked in git, so
-#         local docs generation dirties the tree. Prefer these as build-only artifacts (CI publishes
-#         them) rather than tracked outputs developers must constantly revert.
+# TODO: doc/site/data/* are pipeline outputs tracked in git; prefer build-only artifacts.
 
 # Reset generated doc data files
 reset:

--- a/just/engine.just
+++ b/just/engine.just
@@ -7,11 +7,10 @@ build *args:
     #!/usr/bin/env bash
     set -euo pipefail
     source "$DEVTOOLS_DIR/scripts/common.sh"
+    require_host
+    source "$DEVTOOLS_DIR/scripts/setup.sh"
+    require_repo recoil RecoilEngine "RecoilEngine"
     build_script="$DEVTOOLS_DIR/RecoilEngine/docker-build-v2/build.sh"
-    if [ ! -f "$build_script" ]; then
-        err "RecoilEngine not found. Clone it first: just repos::clone extra"
-        exit 1
-    fi
     if [ -z "{{args}}" ]; then
         err "Usage: just engine::build <platform> [cmake-args...]"
         echo ""
@@ -22,4 +21,28 @@ build *args:
         echo "    just engine::build --help"
         exit 1
     fi
-    exec bash "$build_script" {{args}}
+    # Refuse early if a local-build engine is running -- the install step
+    # would corrupt its mmap'd / share-locked binaries.
+    case " {{args}} " in
+      *" --help "*|*" -h "*) ;;
+      *)
+        game_dir="${BAR_DATA_DIR:-$(detect_game_dir 2>/dev/null || true)}"
+        if [ -n "$game_dir" ] && ! holders="$(_engine_holders "$game_dir")"; then
+          err "Cannot build engine -- local-build is currently running:"
+          while IFS= read -r h; do err "  - $h"; done <<<"$holders"
+          err "Stop it first:"
+          err "  just bar::stop"
+          exit 1
+        fi
+        ;;
+    esac
+    bash "$build_script" {{args}}
+    # Skip the mirror for `--help`; otherwise mirror the refreshed install/.
+    case " {{args}} " in
+      *" --help "*|*" -h "*) ;;
+      *)
+        if is_wsl; then
+          bash "$DEVTOOLS_DIR/scripts/sync.sh" mirror-engine
+        fi
+        ;;
+    esac

--- a/just/link.just
+++ b/just/link.just
@@ -17,3 +17,11 @@ create target:
     source "$DEVTOOLS_DIR/scripts/common.sh"
     source "$DEVTOOLS_DIR/scripts/setup.sh"
     cmd_link "{{target}}"
+
+# Remove Devtools symlinks from the game directory (engine, chobby, bar, or all)
+unlink target="all":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    source "$DEVTOOLS_DIR/scripts/setup.sh"
+    cmd_unlink "{{target}}"

--- a/just/lua.just
+++ b/just/lua.just
@@ -10,11 +10,7 @@ build-lde:
     #!/usr/bin/env bash
     set -euo pipefail
     source "$DEVTOOLS_DIR/scripts/common.sh"
-    if [ ! -d "$LDE_DIR" ]; then
-        err "lua-doc-extractor not found at $LDE_DIR"
-        info "Clone it first: just repos::clone extra"
-        exit 1
-    fi
+    require_repo recoil lua-doc-extractor "lua-doc-extractor"
     cd "$LDE_DIR"
     npm ci && npm run build
     ok "lua-doc-extractor built"

--- a/just/repos.just
+++ b/just/repos.just
@@ -4,13 +4,13 @@ DEVTOOLS_DIR := justfile_directory()
 REPOS_CONF   := DEVTOOLS_DIR / "repos.conf"
 REPOS_LOCAL  := DEVTOOLS_DIR / "repos.local.conf"
 
-# Clone or update repos (group: core, extra, or all)
-clone group="all":
+# Clone or update repos (feature: bar, recoil, teiserver, chobby, spads-source, or all)
+clone feature="all":
     #!/usr/bin/env bash
     set -euo pipefail
     source "$DEVTOOLS_DIR/scripts/common.sh"
     source "$DEVTOOLS_DIR/scripts/repos.sh"
-    cmd_clone "{{group}}"
+    cmd_clone "{{feature}}"
 
 # Show status of all configured repositories
 status:
@@ -27,3 +27,11 @@ update:
     source "$DEVTOOLS_DIR/scripts/common.sh"
     source "$DEVTOOLS_DIR/scripts/repos.sh"
     cmd_update
+
+# Normalize remotes to (origin = fork, upstream = canonical). Skips unrecognized layouts.
+fixup:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    source "$DEVTOOLS_DIR/scripts/repos.sh"
+    cmd_fixup

--- a/just/repos.just
+++ b/just/repos.just
@@ -29,9 +29,9 @@ update:
     cmd_update
 
 # Normalize remotes to (origin = fork, upstream = canonical). Skips unrecognized layouts.
-fixup:
+standardize-remotes:
     #!/usr/bin/env bash
     set -euo pipefail
     source "$DEVTOOLS_DIR/scripts/common.sh"
     source "$DEVTOOLS_DIR/scripts/repos.sh"
-    cmd_fixup
+    cmd_standardize_remotes

--- a/just/services.just
+++ b/just/services.just
@@ -2,7 +2,7 @@ set export
 
 DEVTOOLS_DIR := justfile_directory()
 COMPOSE_FILE := DEVTOOLS_DIR / "docker-compose.dev.yml"
-COMPOSE      := "docker compose -f " + COMPOSE_FILE
+COMPOSE      := "podman compose -f " + COMPOSE_FILE
 LOBBY_DIR    := DEVTOOLS_DIR / "bar-lobby"
 
 # Start dev services. Options: lobby, spads
@@ -10,6 +10,7 @@ up *args:
     #!/usr/bin/env bash
     set -euo pipefail
     source "$DEVTOOLS_DIR/scripts/common.sh"
+    require_host
     source "$DEVTOOLS_DIR/scripts/setup.sh"
     install_dockerignore
 
@@ -80,10 +81,7 @@ up *args:
     echo ""
 
     if [ "$start_lobby" -eq 1 ]; then
-        if [ ! -d "$LOBBY_DIR" ]; then
-            err "bar-lobby directory not found. Run 'just repos::clone' first."
-            exit 1
-        fi
+        require_repo bar,chobby bar-lobby "bar-lobby"
         if ! command -v node &>/dev/null; then
             err "Node.js is required for bar-lobby. Run 'just setup::deps'."
             exit 1
@@ -102,18 +100,28 @@ up *args:
 
 # Stop all services
 down:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    require_host
     $COMPOSE --profile spads down
 
 # Show running services
 status:
     #!/usr/bin/env bash
-    echo -e "\033[1m=== Service Status ===\033[0m"
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    require_host
+    echo -e "${BOLD}=== Service Status ===${NC}"
     echo ""
     $COMPOSE --profile spads ps -a
 
 # Tail service logs
 logs service="":
     #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    require_host
     if [ -z "{{service}}" ]; then
         $COMPOSE --profile spads logs -f --tail=100
     else
@@ -125,11 +133,7 @@ lobby:
     #!/usr/bin/env bash
     set -euo pipefail
     source "$DEVTOOLS_DIR/scripts/common.sh"
-    if [ ! -d "$LOBBY_DIR" ]; then
-        err "bar-lobby directory not found at: $LOBBY_DIR"
-        err "Run 'just repos::clone' to clone repositories first."
-        exit 1
-    fi
+    require_repo bar,chobby bar-lobby "bar-lobby"
     if ! command -v node &>/dev/null; then
         err "Node.js is required for bar-lobby. Run 'just setup::deps'."
         exit 1
@@ -147,6 +151,10 @@ lobby:
 
 # Open a shell in a container
 shell service="teiserver":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    require_host
     $COMPOSE --profile spads exec {{service}} bash
 
 # Build Docker images
@@ -154,6 +162,7 @@ build:
     #!/usr/bin/env bash
     set -euo pipefail
     source "$DEVTOOLS_DIR/scripts/common.sh"
+    require_host
     source "$DEVTOOLS_DIR/scripts/setup.sh"
     install_dockerignore
     info "Building Docker images..."
@@ -171,6 +180,7 @@ reset:
     #!/usr/bin/env bash
     set -euo pipefail
     source "$DEVTOOLS_DIR/scripts/common.sh"
+    require_host
     info "Stopping services and removing volumes..."
     $COMPOSE --profile spads down -v
     info "Rebuilding images from scratch..."

--- a/just/setup.just
+++ b/just/setup.just
@@ -2,7 +2,7 @@ set export
 
 DEVTOOLS_DIR := justfile_directory()
 COMPOSE_FILE := DEVTOOLS_DIR / "docker-compose.dev.yml"
-COMPOSE      := "docker compose -f " + COMPOSE_FILE
+COMPOSE      := "podman compose -f " + COMPOSE_FILE
 REPOS_CONF   := DEVTOOLS_DIR / "repos.conf"
 REPOS_LOCAL  := DEVTOOLS_DIR / "repos.local.conf"
 
@@ -15,6 +15,16 @@ init *args:
     source "$DEVTOOLS_DIR/scripts/setup.sh"
     cmd_init {{args}}
 
+# Re-run setup, re-prompting every saved .env decision (features, ssh, ...)
+reconfigure *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    source "$DEVTOOLS_DIR/scripts/repos.sh"
+    source "$DEVTOOLS_DIR/scripts/setup.sh"
+    export BAR_RESET_CONFIG=1
+    cmd_init {{args}}
+
 # Install system packages (git, podman/docker, distrobox)
 deps:
     #!/usr/bin/env bash
@@ -23,56 +33,26 @@ deps:
     source "$DEVTOOLS_DIR/scripts/setup.sh"
     cmd_install_deps
 
-# Build dev container image and create distrobox
-distrobox:
+# Build dev container image and create distrobox (--rebuild forces lux cache wipe)
+distrobox *args:
     #!/usr/bin/env bash
     set -euo pipefail
     source "$DEVTOOLS_DIR/scripts/common.sh"
     source "$DEVTOOLS_DIR/scripts/setup.sh"
-    cmd_setup_distrobox
+    cmd_setup_distrobox {{args}}
 
-# Export distrobox binaries for editor integration (clangd, emmylua_ls, stylua)
+# Wire your editor up for BAR development (idempotent)
 editor:
     #!/usr/bin/env bash
     set -euo pipefail
     source "$DEVTOOLS_DIR/scripts/common.sh"
-    if [ -z "${DEVTOOLS_DISTROBOX:-}" ]; then
-        err "DEVTOOLS_DISTROBOX not set. Run: just setup::distrobox"
-        exit 1
-    fi
-    local_bin="$HOME/.local/bin"
-    mkdir -p "$local_bin"
-    for bin in /usr/local/bin/emmylua_ls /usr/bin/clangd /usr/local/bin/stylua; do
-        name="$(basename "$bin")"
-        info "Exporting $name..."
-        distrobox enter "$DEVTOOLS_DISTROBOX" -- distrobox-export --bin "$bin" --export-path "$local_bin"
-    done
-    echo ""
-    if [ -f "$DEVTOOLS_DIR/RecoilEngine/CMakeLists.txt" ]; then
-        step "Generating compile_commands.json for clangd..."
-        distrobox enter "$DEVTOOLS_DISTROBOX" -- bash -c "
-            cd '$DEVTOOLS_DIR/RecoilEngine' \
-            && mkdir -p build \
-            && cd build \
-            && cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .. 2>&1 | tail -3
-        "
-        ln -sf build/compile_commands.json "$DEVTOOLS_DIR/RecoilEngine/compile_commands.json"
-        ok "compile_commands.json ready"
-    else
-        info "RecoilEngine not cloned — skipping compile_commands.json"
-    fi
-    echo ""
-    ok "Editor integration ready."
-    echo ""
-    info "Install these VS Code / Cursor extensions:"
-    echo "  - EmmyLua (tangzx.emmylua) — Cursor users: install from VSIX, marketplace version is outdated"
-    echo "    https://marketplace.visualstudio.com/items?itemName=tangzx.emmylua"
-    echo "  - StyLua (JohnnyMorganz.stylua)"
-    echo "  - clangd (llvm-vs-code-extensions.vscode-clangd) — for engine C++ work"
-    echo ""
-    info "Add to your editor settings (JSON):"
-    echo '  "emmylua.ls.executablePath": "~/.local/bin/emmylua_ls",'
-    echo '  "[lua]": { "editor.defaultFormatter": "JohnnyMorganz.stylua", "editor.formatOnSave": true }'
+    source "$DEVTOOLS_DIR/scripts/setup.sh"
+
+    sed -i '/^BAR_EDITOR_/d' "$DEVTOOLS_DIR/.env" 2>/dev/null || true
+    editor_collect_state
+    _editor_show_preamble
+    echo "BAR_EDITOR_SETUP=yes" >> "$DEVTOOLS_DIR/.env"
+    cmd_setup_editor
 
 # Install git pre-commit hooks (stylua + luacheck) in BAR repo
 hooks:
@@ -93,5 +73,6 @@ doctor:
     set -euo pipefail
     source "$DEVTOOLS_DIR/scripts/common.sh"
     source "$DEVTOOLS_DIR/scripts/repos.sh"
+    source "$DEVTOOLS_DIR/scripts/setup.sh"
     source "$DEVTOOLS_DIR/scripts/doctor.sh"
     cmd_doctor

--- a/just/ssh.just
+++ b/just/ssh.just
@@ -1,0 +1,40 @@
+set export
+
+DEVTOOLS_DIR := justfile_directory()
+
+# Set up 1Password SSH agent (Windows + WSL bridge, or native Linux) and op CLI
+op-setup *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    bash "$DEVTOOLS_DIR/scripts/ssh/setup-op-ssh.sh" {{args}}
+
+# Generate ~/.ssh/id_ed25519, start ssh-agent, walk through GitHub key registration
+manual-setup *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    bash "$DEVTOOLS_DIR/scripts/ssh/setup-manual-ssh.sh" {{args}}
+
+# Just the WSL bridge half (assumes 1Password Desktop is already on Windows)
+wsl-bridge:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    bash "$DEVTOOLS_DIR/scripts/ssh/setup-wsl-ssh.sh"
+
+# Read-only health check: agent reachable, keys loaded, GitHub accepts them
+doctor:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    source "$DEVTOOLS_DIR/scripts/ssh/lib.sh"
+    info "SSH_AUTH_SOCK=${SSH_AUTH_SOCK:-(unset)}"
+    op_ssh_verify || true
+    if command -v op >/dev/null; then
+        if op whoami 2>&1; then
+            ok "op CLI signed in."
+        else
+            warn "op CLI installed but not signed in (run: op signin)."
+        fi
+    fi

--- a/just/tei.just
+++ b/just/tei.just
@@ -2,33 +2,41 @@ set export
 
 DEVTOOLS_DIR    := justfile_directory()
 COMPOSE_FILE    := DEVTOOLS_DIR / "docker-compose.dev.yml"
-COMPOSE         := "docker compose -f " + COMPOSE_FILE
+COMPOSE         := "podman compose -f " + COMPOSE_FILE
 TEISERVER_DIR   := DEVTOOLS_DIR / "teiserver"
 
 [private]
 require-setup:
     #!/usr/bin/env bash
-    if [ ! -d "{{TEISERVER_DIR}}" ]; then
-        echo "Error: teiserver is not cloned." >&2
-        echo "Run: just setup::init" >&2
-        exit 1
-    fi
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    require_repo teiserver teiserver "Teiserver"
 
 # Initialize and migrate the test database
 setup-test-db: require-setup
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    require_host
     {{COMPOSE}} run --rm -e MIX_ENV=test --entrypoint "" \
         teiserver bash -c "mix ecto.create --quiet 2>/dev/null; mix ecto.migrate --quiet"
 
-# Run teiserver mix tests
-mix *args: require-setup
+# Run teiserver mix tests (optional path for a single file)
+test *args: require-setup
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    require_host
     {{COMPOSE}} run --rm -e MIX_ENV=test --entrypoint "" \
         -v {{TEISERVER_DIR}}/test:/app/test:z \
         teiserver mix test {{args}}
 
-alias test := mix
-
 # Drop into an interactive test shell for teiserver
 test-shell: require-setup
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    require_host
     {{COMPOSE}} run --rm -e MIX_ENV=test --entrypoint "" \
         -v {{TEISERVER_DIR}}/test:/app/test:z \
         teiserver bash -c "echo 'Entering teiserver test shell (MIX_ENV=test). Type exit to return.' && exec bash"

--- a/repos.conf
+++ b/repos.conf
@@ -1,37 +1,85 @@
 # BAR Development Workspace - Repository Configuration
 # ====================================================
 #
-# Format:  directory  url  branch  group  [local_path]
+# Format:  directory  url  branch  feature  [local_path]
 #
 #   directory  - local folder name (relative to this workspace)
 #   url        - git clone URL
 #   branch     - branch to checkout after cloning
-#   group      - "core" (needed for devtools stack) or "extra" (optional)
+#   feature    - comma-separated feature tags. Valid tags:
+#                  bar           BAR game content + bar-lobby client
+#                  recoil        Recoil engine + Lua tooling
+#                  teiserver     Teiserver, SPADS config, db / live services
+#                  chobby        Chobby (in-game lobby)
+#                  spads-source  SPADS autohost source (optional)
+#                A repo with multiple tags shows up under each feature
+#                (e.g. bar-lobby is needed for both `bar` and `chobby`).
 #   local_path - (optional) symlink to an existing checkout instead of cloning
 #
-# To use your own fork, copy this file to repos.local.conf and change the URLs.
-# repos.local.conf overrides repos.conf and is gitignored.
+# repos.local.conf overrides repos.conf and is gitignored. Override is
+# per-field: any column you omit falls back to what repos.conf says,
+# and only the `directory` column is required (it's the join key). So
+# overriding a fork's URL is a one-column line:
+#
+#   bar_debug_launcher   git@github.com:keithharvey/bar_debug_launcher.git
+#
+# (no need to repeat branch/feature/local_path -- they inherit).
 #
 # Lines starting with # are comments. Empty lines are ignored.
+#
+# `just repos::clone` reconciles the workspace to this config idempotently:
+# a real directory where config wants a symlink is moved aside to .backups/
+# (or promoted to the canonical path if that slot is free), and a stale
+# symlink where config wants an in-place clone is replaced -- no manual
+# cleanup needed, and nothing is ever deleted.
+#
+# Directives (in repos.local.conf):
+#   @local_root <path>     for every repo, use <path>/<dir> as the local checkout
+#                          (auto-cloned and symlinked into the workspace).
+#                          Per-row local_path columns still win.
+#   @protocol ssh|https    rewrite github.com URLs between SSH and HTTPS.
+#                          Use 'ssh' for push-by-default; auto-pinned by
+#                          'just ssh::op-setup' after github.com auth works.
+#
+# Example minimal repos.local.conf:
+#   @local_root ~/code
+#   @protocol ssh
+#   bar_debug_launcher   git@github.com:keithharvey/bar_debug_launcher.git
 
 # ---------------------------------------------------------------------------
-# Core: required for ./devtools.sh up
+# bar — BAR game content + bar-lobby client
 # ---------------------------------------------------------------------------
 
-teiserver            https://github.com/beyond-all-reason/teiserver.git             main      core
-bar-lobby            https://github.com/beyond-all-reason/bar-lobby.git             master    core
-spads_config_bar     https://github.com/beyond-all-reason/spads_config_bar.git      main      core
+Beyond-All-Reason    https://github.com/beyond-all-reason/Beyond-All-Reason.git    master    bar
+bar-lobby            https://github.com/beyond-all-reason/bar-lobby.git             master    bar,chobby
+bar_debug_launcher   https://github.com/beyond-all-reason/bar_debug_launcher.git    main      bar,recoil,chobby
 
 # ---------------------------------------------------------------------------
-# Extra: useful but not required for the base dev stack
+# recoil — Recoil engine + Lua tooling that operates on engine source
 # ---------------------------------------------------------------------------
 
-ansible-spads-setup  https://github.com/beyond-all-reason/ansible-spads-setup.git   main      extra
-Beyond-All-Reason    https://github.com/beyond-all-reason/Beyond-All-Reason.git    master    extra
-BYAR-Chobby          https://github.com/beyond-all-reason/BYAR-Chobby.git          master    extra
-bar-db               https://github.com/beyond-all-reason/bar-db.git                master    extra
-bar-live-services    https://github.com/beyond-all-reason/bar-live-services.git     main      extra
-RecoilEngine         https://github.com/beyond-all-reason/RecoilEngine.git         master    extra
-lua-doc-extractor    https://github.com/rhys-vdw/lua-doc-extractor                 main      extra
-SPADS                https://github.com/Yaribz/SPADS.git                            master    extra
-SpringLobbyInterface https://github.com/Yaribz/SpringLobbyInterface.git            master    extra
+RecoilEngine         https://github.com/beyond-all-reason/RecoilEngine.git         master    recoil
+lua-doc-extractor    https://github.com/rhys-vdw/lua-doc-extractor                  main      recoil
+
+# ---------------------------------------------------------------------------
+# teiserver — Teiserver lobby/matchmaking server, SPADS config, public APIs
+# ---------------------------------------------------------------------------
+
+teiserver            https://github.com/beyond-all-reason/teiserver.git             main      teiserver
+spads_config_bar     https://github.com/beyond-all-reason/spads_config_bar.git      main      teiserver
+bar-db               https://github.com/beyond-all-reason/bar-db.git                master    teiserver
+bar-live-services    https://github.com/beyond-all-reason/bar-live-services.git     main      teiserver
+
+# ---------------------------------------------------------------------------
+# chobby — Chobby in-game lobby
+# ---------------------------------------------------------------------------
+
+BYAR-Chobby          https://github.com/beyond-all-reason/BYAR-Chobby.git           master    chobby
+
+# ---------------------------------------------------------------------------
+# spads-source — SPADS autohost source (optional, for SPADS dev only)
+# ---------------------------------------------------------------------------
+
+SPADS                https://github.com/Yaribz/SPADS.git                            master    spads-source
+SpringLobbyInterface https://github.com/Yaribz/SpringLobbyInterface.git             master    spads-source
+ansible-spads-setup  https://github.com/beyond-all-reason/ansible-spads-setup.git   main      spads-source

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Installs `just` (>= MIN_JUST_VERSION) to ~/.local/bin. Run before the first
+# `just setup::init`. Debian/Ubuntu LTS ships a `just` too old for `mod` and
+# `[confirm(...)]` syntax, so we use the upstream installer. Idempotent.
+#
+#   curl -fsSL https://raw.githubusercontent.com/<repo>/<branch>/scripts/bootstrap.sh | bash
+#   bash scripts/bootstrap.sh
+
+set -euo pipefail
+
+MIN_JUST_VERSION="1.31.0"
+
+RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[1;33m'
+BLUE=$'\033[0;34m'; BOLD=$'\033[1m'; NC=$'\033[0m'
+info() { echo "${BLUE}[info]${NC}  $*"; }
+ok()   { echo "${GREEN}[ok]${NC}    $*"; }
+warn() { echo "${YELLOW}[warn]${NC}  $*"; }
+err()  { echo "${RED}[error]${NC} $*" >&2; }
+
+# returns 0 iff $1 >= $2
+version_ge() {
+  local a="$1" b="$2" IFS=.
+  local -a A=($a) B=($b)
+  for i in 0 1 2; do
+    local av="${A[i]:-0}" bv="${B[i]:-0}"
+    (( av > bv )) && return 0
+    (( av < bv )) && return 1
+  done
+  return 0
+}
+
+current_just_version() {
+  command -v just >/dev/null 2>&1 || return 1
+  just --version 2>/dev/null | awk '{print $2}'
+}
+
+ensure_local_bin_on_path() {
+  local rc bin="$HOME/.local/bin"
+  case "${SHELL:-}" in
+    *zsh)  rc="$HOME/.zshrc" ;;
+    *)     rc="$HOME/.bashrc" ;;
+  esac
+  mkdir -p "$bin"
+  local line='export PATH="$HOME/.local/bin:$PATH"'
+  if ! grep -qxF "$line" "$rc" 2>/dev/null; then
+    printf '\n%s\n' "$line" >> "$rc"
+    info "Added ~/.local/bin to PATH in $rc"
+  fi
+  case ":${PATH}:" in
+    *":$bin:"*) ;;
+    *) export PATH="$bin:$PATH" ;;
+  esac
+}
+
+install_just() {
+  info "Installing just to ~/.local/bin via the upstream installer..."
+  if ! command -v curl >/dev/null 2>&1; then
+    err "curl is required to bootstrap. Install it first:"
+    err "  Ubuntu/Debian: sudo apt install -y curl"
+    err "  Arch:          sudo pacman -S curl"
+    err "  Fedora:        sudo dnf install -y curl"
+    exit 1
+  fi
+  curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
+    | bash -s -- --to "$HOME/.local/bin" >/dev/null
+}
+
+main() {
+  echo "${BOLD}BAR-Devtools bootstrap${NC} — ensuring \`just\` >= ${MIN_JUST_VERSION}"
+  echo ""
+
+  ensure_local_bin_on_path
+
+  local current
+  if current="$(current_just_version)" && version_ge "$current" "$MIN_JUST_VERSION"; then
+    ok "just $current already satisfies the minimum (>= $MIN_JUST_VERSION)"
+  else
+    if [ -n "${current:-}" ]; then
+      warn "found just $current, need >= $MIN_JUST_VERSION — upgrading"
+    fi
+    install_just
+    hash -r 2>/dev/null || true
+    current="$(current_just_version)" || {
+      err "just still not on PATH after install. Open a new shell and re-run, or"
+      err "  source ~/.bashrc  (or ~/.zshrc)"
+      exit 1
+    }
+    if version_ge "$current" "$MIN_JUST_VERSION"; then
+      ok "Installed just $current"
+    else
+      err "Installer produced just $current, which is still below $MIN_JUST_VERSION."
+      err "Upstream installer may be pinned; check https://just.systems/."
+      exit 1
+    fi
+  fi
+
+  echo ""
+  info "Next steps:"
+  info "  1. Open a new shell (or 'source ~/.bashrc' / 'source ~/.zshrc')"
+  info "  2. cd into the BAR-Devtools checkout"
+  info "  3. just setup::init"
+}
+
+main "$@"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -35,20 +35,35 @@ current_just_version() {
 }
 
 ensure_local_bin_on_path() {
-  local rc bin="$HOME/.local/bin"
+  local bin="$HOME/.local/bin"
+  mkdir -p "$bin"
+  case ":${PATH}:" in
+    *":$bin:"*) return 0 ;;   # already resolvable -- leave the rc alone
+  esac
+
+  local rc
   case "${SHELL:-}" in
     *zsh)  rc="$HOME/.zshrc" ;;
     *)     rc="$HOME/.bashrc" ;;
   esac
-  mkdir -p "$bin"
-  local line='export PATH="$HOME/.local/bin:$PATH"'
-  if ! grep -qxF "$line" "$rc" 2>/dev/null; then
-    printf '\n%s\n' "$line" >> "$rc"
-    info "Added ~/.local/bin to PATH in $rc"
+
+  warn "$bin is not on your PATH -- just, bar-launch, and editor tools install there."
+  local add=y
+  if (exec </dev/tty) 2>/dev/null; then   # openable tty? (node may exist but ENXIO without one)
+    printf "  Add it to %s? [Y/n] " "${rc/#$HOME/~}" > /dev/tty
+    read -r add < /dev/tty || add=y
   fi
-  case ":${PATH}:" in
-    *":$bin:"*) ;;
-    *) export PATH="$bin:$PATH" ;;
+  export PATH="$bin:$PATH"   # this shell works either way, so install_just + setup::init run
+  case "${add:-y}" in
+    [Nn]*)
+      warn "Leaving $rc untouched. Add this yourself or new shells won't find just:"
+      warn '  export PATH="$HOME/.local/bin:$PATH"'
+      ;;
+    *)
+      local line='export PATH="$HOME/.local/bin:$PATH"'
+      grep -qxF "$line" "$rc" 2>/dev/null || printf '\n%s\n' "$line" >> "$rc"
+      info "Added ~/.local/bin to PATH in ${rc/#$HOME/~} -- open a new shell or source it."
+      ;;
   esac
 }
 

--- a/scripts/chobby-channel.sh
+++ b/scripts/chobby-channel.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Force Chobby's gameConfig channel ("byar-dev" vs "byar") to a known value.
+#
+# Chobby stores the channel in two files that must agree, or the dropdown
+# silently reverts: chobby_config.json ("game" field, used on fresh install)
+# and LuaMenu/Config/IGL_data.lua (["Chili lobby"].gameConfigName, written
+# once widget state exists and clobbers chobby_config.json after init).
+# set_chobby_channel writes both, idempotently.
+
+_chobby_game_field() {
+    local cfg="$1"
+    [ -f "$cfg" ] || return 0
+    grep -oE '"game"[[:space:]]*:[[:space:]]*"[^"]+"' "$cfg" 2>/dev/null \
+        | sed -E 's/.*"([^"]+)"$/\1/' | tr -d '\r' | head -n1
+}
+
+# patch chobby_config.json "game" field to $2; byte-idempotent (matters on
+# /mnt/c where any write bumps mtime through sync/inotify chains)
+_write_chobby_game() {
+    local cfg="$1" game="$2"
+    python3 - "$cfg" "$game" <<'PY'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1])
+game = sys.argv[2]
+data = {}
+if p.exists():
+    try:
+        data = json.loads(p.read_text())
+    except Exception:
+        data = {}
+data["game"] = game
+new = json.dumps(data, indent=2) + "\n"
+if p.exists() and p.read_text() == new:
+    sys.exit(0)
+p.parent.mkdir(parents=True, exist_ok=True)
+p.write_text(new)
+PY
+}
+
+# echo persisted ["Chili lobby"].gameConfigName from IGL_data.lua; empty if absent
+_chobby_widget_game_field() {
+    local data_dir="$1"
+    local f="$data_dir/LuaMenu/Config/IGL_data.lua"
+    [ -f "$f" ] || return 0
+    python3 - "$f" 2>/dev/null <<'PY' || true
+import re, sys, pathlib
+text = pathlib.Path(sys.argv[1]).read_bytes().decode('utf-8', errors='replace')
+i = text.find('["Chili lobby"]')
+if i < 0: sys.exit(0)
+j = text.find('{', i)
+if j < 0: sys.exit(0)
+depth, end = 0, -1
+for k in range(j, len(text)):
+    c = text[k]
+    if c == '{': depth += 1
+    elif c == '}':
+        depth -= 1
+        if depth == 0:
+            end = k
+            break
+if end < 0: sys.exit(0)
+m = re.search(r'\bgameConfigName\s*=\s*"([^"]*)"', text[j:end+1])
+if m: print(m.group(1))
+PY
+}
+
+# patch ["Chili lobby"].gameConfigName in IGL_data.lua to $2; no-op if absent.
+# round-trips bytes to preserve CRLF (Spring writes the file from Windows)
+_write_chobby_widget_game() {
+    local data_dir="$1" game="$2"
+    local f="$data_dir/LuaMenu/Config/IGL_data.lua"
+    [ -f "$f" ] || return 0
+    python3 - "$f" "$game" <<'PY'
+import re, sys, pathlib
+p = pathlib.Path(sys.argv[1])
+desired = sys.argv[2]
+raw = p.read_bytes()
+text = raw.decode('utf-8', errors='replace')
+i = text.find('["Chili lobby"]')
+if i < 0: sys.exit(0)
+j = text.find('{', i)
+if j < 0: sys.exit(0)
+depth, end = 0, -1
+for k in range(j, len(text)):
+    c = text[k]
+    if c == '{': depth += 1
+    elif c == '}':
+        depth -= 1
+        if depth == 0:
+            end = k
+            break
+if end < 0: sys.exit(0)
+block = text[j:end+1]
+new_block, n = re.subn(
+    r'(\bgameConfigName\s*=\s*)"[^"]*"',
+    lambda m: m.group(1) + '"' + desired + '"',
+    block, count=1,
+)
+if n == 0 or new_block == block:
+    sys.exit(0)
+new_raw = (text[:j] + new_block + text[end+1:]).encode('utf-8')
+if new_raw != raw:
+    p.write_bytes(new_raw)
+PY
+}
+
+# force both chobby state files to channel $2; best-effort, always returns 0
+set_chobby_channel() {
+    local data_dir="$1" game="$2"
+    [ -n "$data_dir" ] && [ -n "$game" ] || return 0
+    _write_chobby_game        "$data_dir/chobby_config.json"   "$game"
+    _write_chobby_widget_game "$data_dir"                      "$game"
+}

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,21 +1,130 @@
 #!/usr/bin/env bash
 # Shared helpers for BAR-Devtools scripts.
-# Source this file; it only defines functions and variables.
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-DIM='\033[2m'
-NC='\033[0m'
+: "${DEVTOOLS_DISTROBOX:=bar-dev}"
+export DEVTOOLS_DISTROBOX
+
+# WSL-only sister container hosting the sync daemon (scripts/sync.sh).
+: "${DEVTOOLS_SYNC_DISTROBOX:=bar-sync}"
+export DEVTOOLS_SYNC_DISTROBOX
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[1;33m'
+BLUE=$'\033[0;34m'
+CYAN=$'\033[0;36m'
+BOLD=$'\033[1m'
+DIM=$'\033[2m'
+NC=$'\033[0m'
 
 info()  { echo -e "${BLUE}[info]${NC}  $*"; }
 ok()    { echo -e "${GREEN}[ok]${NC}    $*"; }
 warn()  { echo -e "${YELLOW}[warn]${NC}  $*"; }
 err()   { echo -e "${RED}[error]${NC} $*"; }
 step()  { echo -e "${CYAN}[step]${NC}  $*"; }
+
+: "${SETUP_ENV_FILE:=$DEVTOOLS_DIR/.env}"
+
+# echo value of key $1 from .env, stripping surrounding quotes
+read_env_key() {
+    local key="$1"
+    [ -f "$SETUP_ENV_FILE" ] || return 0
+    local val
+    val="$(grep -E "^${key}=" "$SETUP_ENV_FILE" 2>/dev/null | tail -n1 | cut -d= -f2-)"
+    val="${val%\"}"; val="${val#\"}"
+    printf '%s' "$val"
+}
+
+# upsert $1=$2 into .env
+write_env_key() {
+    local key="$1" val="$2"
+    touch "$SETUP_ENV_FILE"
+    if grep -q "^${key}=" "$SETUP_ENV_FILE" 2>/dev/null; then
+        sed -i "s|^${key}=.*|${key}=${val}|" "$SETUP_ENV_FILE"
+    else
+        printf '%s=%s\n' "$key" "$val" >> "$SETUP_ENV_FILE"
+    fi
+}
+
+# true if csv list $1 contains tag $2
+features_include() {
+    local IFS=','
+    local f
+    for f in $1; do
+        [ "$f" = "$2" ] && return 0
+    done
+    return 1
+}
+
+# true if any of $1 (csv) is in the active BAR_FEATURES (read live from .env)
+feature_selected() {
+    local want="$1" sel f
+    sel="$(read_env_key BAR_FEATURES)"
+    local IFS=','
+    for f in $want; do
+        features_include "$sel" "$f" && return 0
+    done
+    return 1
+}
+
+# guard for recipes needing a cloned repo: <feature-csv> <repo-dir> <human-name>
+require_repo() {
+    local feats="$1" dir="$2" name="$3"
+    [ -d "$DEVTOOLS_DIR/$dir" ] && return 0
+    if feature_selected "$feats"; then
+        err "${name} is selected but not cloned."
+        info "Run: just repos::clone ${feats%%,*}"
+    else
+        err "${name} isn't in your selected features (BAR_FEATURES)."
+        info "Add it: just setup::reconfigure  (or clone directly: just repos::clone ${feats%%,*})"
+    fi
+    return 1
+}
+
+is_wsl() {
+    [ -n "${WSL_DISTRO_NAME:-}" ] || [ -f /proc/sys/fs/binfmt_misc/WSLInterop ]
+}
+
+# echo running engine processes that have the local-build binaries open
+# (engine::build would corrupt them); game dir from $1 or $BAR_DATA_DIR
+_engine_holders() {
+    local game_dir="${1:-${BAR_DATA_DIR:-}}"
+    [ -n "$game_dir" ] || return 0
+    local local_build="$game_dir/engine/local-build"
+    [ -e "$local_build" ] || return 0
+
+    local holders=()
+    if is_wsl; then
+        command -v powershell.exe &>/dev/null || return 0
+        local win_local
+        win_local="$(wslpath -w "$local_build" 2>/dev/null)" || return 0
+        local matches
+        matches="$(powershell.exe -NoProfile -NonInteractive -Command "
+            Get-CimInstance Win32_Process -Filter \"Name='spring.exe' OR Name='Beyond-All-Reason.exe'\" 2>\$null |
+              Where-Object { \$_.ExecutablePath -and \$_.ExecutablePath.StartsWith('$win_local', [StringComparison]::OrdinalIgnoreCase) } |
+              Select-Object -ExpandProperty Name
+        " 2>/dev/null | tr -d '\r' | sort -u | grep -v '^$' || true)"
+        [ -n "$matches" ] && mapfile -t holders <<<"$matches"
+    else
+        # /proc/PID/exe resolves through symlinks, so compare resolved paths
+        local local_real proc pid exe
+        local_real="$(readlink -f "$local_build" 2>/dev/null || echo "$local_build")"
+        for proc in spring spring-headless; do
+            for pid in $(pgrep -x "$proc" 2>/dev/null || true); do
+                exe="$(readlink "/proc/$pid/exe" 2>/dev/null)" || continue
+                case "$exe" in
+                    "$local_real"/*|"$local_build"/*) holders+=("$proc (pid $pid)") ;;
+                esac
+            done
+        done
+    fi
+
+    if [ "${#holders[@]}" -gt 0 ]; then
+        printf '%s\n' "${holders[@]}"
+        return 1
+    fi
+    return 0
+}
 
 # Remove a directory that may contain files owned by a container runtime.
 clean_dir() {
@@ -33,24 +142,49 @@ clean_dir() {
         [ -d "$dir" ] || return 0
     fi
 
-    if command -v docker &>/dev/null; then
-        warn "Retrying removal via docker..."
-        docker run --rm -v "$parent:/p:z" alpine rm -rf "/p/$name"
-        return $?
-    fi
-
     err "Cannot remove $dir — files owned by another user"
     err "Try: sudo rm -rf '$dir'"
     return 1
 }
 
-# Re-execute the calling script inside a distrobox if DEVTOOLS_DISTROBOX is set.
-# Just writes shebang scripts to temp files under /run/user/... which isn't
-# shared with distrobox, so we feed the script via stdin (< "$0") before exec.
+# true if we're inside a container (spawned by us, or entered interactively)
+_in_container() {
+    [ -n "${_DEVTOOLS_IN_DISTROBOX:-}" ] || [ -f /run/.containerenv ] || [ -f /.dockerenv ]
+}
+
+# refuse to run inside a container; for recipes needing the host podman daemon
+require_host() {
+    if _in_container; then
+        err "This recipe runs on the host (needs podman) -- not from inside bar-dev."
+        info "  Exit the container ('exit' or Ctrl-D), then re-run."
+        exit 1
+    fi
+}
+
+# re-exec the calling script inside DEVTOOLS_DISTROBOX (fed via stdin, since
+# Just's temp scripts under /run/user aren't visible to the container)
 enter_distrobox() {
-    if [ -n "${DEVTOOLS_DISTROBOX:-}" ] && [ -z "${_DEVTOOLS_IN_DISTROBOX:-}" ]; then
+    if [ -n "${DEVTOOLS_DISTROBOX:-}" ] && ! _in_container; then
         info "Entering distrobox '$DEVTOOLS_DISTROBOX'..."
         exec distrobox enter "$DEVTOOLS_DISTROBOX" -- \
             env _DEVTOOLS_IN_DISTROBOX=1 bash -s -- "$@" < "$0"
     fi
+}
+
+# run a single interactive command inside the distrobox with a real PTY.
+# script(1) is the PTY wrapper; it parses its arg via /bin/sh, hence printf %q.
+distrobox_exec_interactive() {
+    if _in_container; then
+        exec "$@"
+    fi
+    if [ -z "${DEVTOOLS_DISTROBOX:-}" ]; then
+        err "DEVTOOLS_DISTROBOX not set. Run: just setup::distrobox"
+        return 1
+    fi
+    local quoted_box quoted_cmd="" arg
+    quoted_box="$(printf '%q' "$DEVTOOLS_DISTROBOX")"
+    for arg in "$@"; do
+        quoted_cmd+=" $(printf '%q' "$arg")"
+    done
+    exec script -qec "distrobox enter ${quoted_box} --${quoted_cmd}" /dev/null
 }

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -85,6 +85,38 @@ is_wsl() {
     [ -n "${WSL_DISTRO_NAME:-}" ] || [ -f /proc/sys/fs/binfmt_misc/WSLInterop ]
 }
 
+# returns 0 if $1 >= $2 (dotted numeric versions), else 1
+_ver_ge() {
+    local IFS=.
+    local -a a=($1) b=($2)
+    local i max=${#a[@]}
+    [ "${#b[@]}" -gt "$max" ] && max=${#b[@]}
+    for ((i=0; i<max; i++)); do
+        local ai=${a[i]:-0} bi=${b[i]:-0}
+        if (( 10#$ai > 10#$bi )); then return 0; fi
+        if (( 10#$ai < 10#$bi )); then return 1; fi
+    done
+    return 0
+}
+
+# WSL2: nudge toward virtiofs for /mnt/c (faster than Plan 9 drvfs -- the sync
+# write path). Key is undocumented + experimental; gated on kernel only, since
+# the DeviceHost version isn't visible from Linux. No-op off WSL / on old kernels.
+wsl_virtiofs_hint() {
+    is_wsl || return 0
+    if [ "$(awk '$2=="/mnt/c"{print $3; exit}' /proc/mounts)" = "virtiofs" ]; then
+        ok "WSL2 /mnt/c is on virtiofs"
+        return 0
+    fi
+    local kver
+    kver="$(uname -r | grep -oE '^[0-9]+(\.[0-9]+)*')"
+    _ver_ge "$kver" 6.18.26.3 || return 0
+    info "WSL2 kernel $kver supports virtiofs (experimental; faster /mnt/c than Plan 9)."
+    info "  Add to %UserProfile%\\.wslconfig, then run 'wsl --shutdown':"
+    info "    [wsl2]"
+    info "    virtiofs=true"
+}
+
 # echo running engine processes that have the local-build binaries open
 # (engine::build would corrupt them); game dir from $1 or $BAR_DATA_DIR
 _engine_holders() {

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -99,6 +99,11 @@ _ver_ge() {
     return 0
 }
 
+# echo the Docker Compose version podman delegates to; empty if absent or the python provider
+_compose_version() {
+    podman compose version 2>/dev/null | grep -i 'Docker Compose version' | sed 's/.*version v\?//; s/[^0-9.].*//'
+}
+
 # WSL2: nudge toward virtiofs for /mnt/c (faster than Plan 9 drvfs -- the sync
 # write path). Key is undocumented + experimental; gated on kernel only, since
 # the DeviceHost version isn't visible from Linux. No-op off WSL / on old kernels.

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Diagnostic checks for BAR-Devtools. Read-only — never modifies anything.
+# Read-only diagnostic checks for BAR-Devtools.
 # Expects: DEVTOOLS_DIR, COMPOSE, REPOS_CONF, REPOS_LOCAL (exported by Justfile)
 
 pass_count=0
@@ -21,18 +21,20 @@ check_doctor_deps() {
     _pass "git $(git --version | awk '{print $3}')"
   fi
 
-  if ! command -v docker &>/dev/null; then
-    _fail "Docker not installed"
+  if ! command -v podman &>/dev/null; then
+    _fail "podman not installed"
     echo "       Run: just setup::deps"
-  elif ! docker info &>/dev/null; then
-    _fail "Docker daemon not running or permission denied"
-    echo "       Start:  sudo systemctl start docker"
-    echo "       Perms:  sudo usermod -aG docker \$USER  (then re-login)"
-  elif ! docker compose version &>/dev/null; then
-    _fail "Docker Compose V2 not installed"
+  elif ! podman info &>/dev/null; then
+    _fail "'podman info' failed (storage init issue?)"
+    echo "       Try: podman system reset  (destroys local images)"
+  elif ! command -v docker-compose &>/dev/null; then
+    _fail "Go docker-compose not installed (podman compose dispatcher needs it as provider)"
     echo "       Run: just setup::deps"
+  elif [ ! -S "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock" ]; then
+    _fail "podman API socket not active (docker-compose can't reach the daemon)"
+    echo "       Run: systemctl --user enable --now podman.socket  (or just setup::deps)"
   else
-    _pass "Docker $(docker --version | awk '{print $3}' | tr -d ',') + Compose V2"
+    _pass "podman $(podman --version | awk '{print $3}') + docker-compose $(docker-compose version --short 2>/dev/null) + socket"
   fi
 
   if ! command -v distrobox &>/dev/null; then
@@ -57,16 +59,11 @@ check_doctor_env() {
     echo "       Not required, but recipes needing distrobox won't auto-enter without it."
   fi
 
-  if [ -n "${DEVTOOLS_DISTROBOX:-}" ]; then
-    if command -v distrobox &>/dev/null && distrobox list 2>/dev/null | grep -q "$DEVTOOLS_DISTROBOX"; then
-      _pass "DEVTOOLS_DISTROBOX=$DEVTOOLS_DISTROBOX (exists)"
-    else
-      _fail "DEVTOOLS_DISTROBOX=$DEVTOOLS_DISTROBOX (container not found)"
-      echo "       Rebuild: just setup::distrobox"
-    fi
-  elif command -v distrobox &>/dev/null; then
-    _warn "DEVTOOLS_DISTROBOX not set — distrobox recipes will fail"
-    echo "       Run: just setup::distrobox"
+  if command -v distrobox &>/dev/null && distrobox list 2>/dev/null | grep -q "$DEVTOOLS_DISTROBOX"; then
+    _pass "DEVTOOLS_DISTROBOX=$DEVTOOLS_DISTROBOX (exists)"
+  else
+    _fail "DEVTOOLS_DISTROBOX=$DEVTOOLS_DISTROBOX (container not found)"
+    echo "       Rebuild: just setup::distrobox"
   fi
 
   echo ""
@@ -121,27 +118,42 @@ check_doctor_repos() {
     return
   fi
 
-  local i missing_extras=()
+  local i missing_features_set=""
+  local -a missing=()
   for i in "${!REPO_DIRS[@]}"; do
     local dir="${REPO_DIRS[$i]}"
-    local group="${REPO_GROUPS[$i]}"
+    local feature="${REPO_FEATURES[$i]:--}"
     local target="$DEVTOOLS_DIR/$dir"
 
     if [ -L "$target" ] && [ -d "$target" ]; then
-      _pass "${dir} (${group}) — linked"
+      _pass "${dir} (${feature}) — linked"
     elif [ -d "$target/.git" ]; then
-      _pass "${dir} (${group})"
-    elif [ "$group" = "core" ]; then
-      _fail "${dir} (${group}) — not cloned"
-      echo "       Run: just repos::clone core"
+      _pass "${dir} (${feature})"
     else
-      missing_extras+=("$dir")
+      missing+=("${dir} (${feature})")
+      # collect distinct feature tags for the `just repos::clone` hint
+      local IFS=','
+      local f
+      for f in $feature; do
+        [ -z "$f" ] && continue
+        case ",$missing_features_set," in
+          *",$f,"*) ;;
+          *)        missing_features_set="${missing_features_set:+$missing_features_set,}$f" ;;
+        esac
+      done
     fi
   done
 
-  if [ "${#missing_extras[@]}" -gt 0 ]; then
-    _warn "${#missing_extras[@]} extra repos not cloned: ${missing_extras[*]}"
-    echo "       Run: just repos::clone extra"
+  if [ "${#missing[@]}" -gt 0 ]; then
+    _warn "${#missing[@]} repos not cloned: ${missing[*]}"
+    if [ -n "$missing_features_set" ]; then
+      local IFS=','
+      local f
+      for f in $missing_features_set; do
+        echo "       Run: just repos::clone $f"
+      done
+    fi
+    echo "       (Or 'just setup::init' for the interactive picker.)"
   fi
 
   echo ""
@@ -149,10 +161,10 @@ check_doctor_repos() {
 
 
 check_doctor_images() {
-  echo -e "${BOLD}Docker images${NC}"
+  echo -e "${BOLD}Container images${NC}"
 
-  if ! command -v docker &>/dev/null || ! docker info &>/dev/null; then
-    _warn "Skipping — Docker not available"
+  if ! command -v podman &>/dev/null || ! podman info &>/dev/null; then
+    _warn "Skipping — podman not available"
     echo ""
     return
   fi
@@ -160,17 +172,17 @@ check_doctor_images() {
   local project_name teiserver_image
   project_name="$(basename "$DEVTOOLS_DIR" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]_-')"
   teiserver_image="${project_name}-teiserver:latest"
-  if docker image inspect "$teiserver_image" &>/dev/null; then
+  if podman image inspect "$teiserver_image" &>/dev/null; then
     _pass "Teiserver image built"
   elif [ ! -d "$DEVTOOLS_DIR/teiserver" ]; then
     _fail "Teiserver image not built (teiserver repo not cloned)"
-    echo "       Run: just repos::clone core && just services::build"
+    echo "       Run: just repos::clone teiserver && just services::build"
   else
     _fail "Teiserver image not built"
     echo "       Run: just services::build"
   fi
 
-  if docker image inspect "badosu/spads:latest" &>/dev/null; then
+  if podman image inspect "badosu/spads:latest" &>/dev/null; then
     _pass "SPADS image available"
   else
     _warn "SPADS image not pulled (optional)"
@@ -184,13 +196,13 @@ check_doctor_images() {
 check_doctor_services() {
   echo -e "${BOLD}Running services${NC}"
 
-  if ! command -v docker &>/dev/null || ! docker info &>/dev/null; then
-    _warn "Skipping — Docker not available"
+  if ! command -v podman &>/dev/null || ! podman info &>/dev/null; then
+    _warn "Skipping — podman not available"
     echo ""
     return
   fi
 
-  local compose="docker compose -f $DEVTOOLS_DIR/docker-compose.dev.yml"
+  local compose="podman compose -f $DEVTOOLS_DIR/docker-compose.dev.yml"
   local any_running=0
 
   for svc in postgres teiserver; do
@@ -239,12 +251,22 @@ check_doctor_services() {
 }
 
 
+check_doctor_modules() {
+  if [ "${#SETUP_MODULES[@]}" -eq 0 ]; then
+    return 0
+  fi
+  echo -e "${BOLD}Setup modules${NC}"
+  doctor_modules
+  echo ""
+}
+
 cmd_doctor() {
   echo -e "${BOLD}=== BAR Devtools Doctor ===${NC}"
   echo ""
 
   check_doctor_deps
   check_doctor_env
+  check_doctor_modules
   check_doctor_ports
   check_doctor_repos
   check_doctor_images

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -70,6 +70,14 @@ check_doctor_env() {
 }
 
 
+check_doctor_wsl() {
+  is_wsl || return 0
+  echo -e "${BOLD}WSL2${NC}"
+  wsl_virtiofs_hint
+  echo ""
+}
+
+
 check_doctor_ports() {
   echo -e "${BOLD}Ports${NC}"
 
@@ -266,6 +274,7 @@ cmd_doctor() {
 
   check_doctor_deps
   check_doctor_env
+  check_doctor_wsl
   check_doctor_modules
   check_doctor_ports
   check_doctor_repos

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -27,14 +27,14 @@ check_doctor_deps() {
   elif ! podman info &>/dev/null; then
     _fail "'podman info' failed (storage init issue?)"
     echo "       Try: podman system reset  (destroys local images)"
-  elif ! command -v docker-compose &>/dev/null; then
-    _fail "Go docker-compose not installed (podman compose dispatcher needs it as provider)"
+  elif ! podman compose version &>/dev/null; then
+    _fail "podman compose not functional (install docker-compose or upgrade podman)"
     echo "       Run: just setup::deps"
   elif [ ! -S "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock" ]; then
     _fail "podman API socket not active (docker-compose can't reach the daemon)"
     echo "       Run: systemctl --user enable --now podman.socket  (or just setup::deps)"
   else
-    _pass "podman $(podman --version | awk '{print $3}') + docker-compose $(docker-compose version --short 2>/dev/null) + socket"
+    _pass "podman $(podman --version | awk '{print $3}') + compose + socket"
   fi
 
   if ! command -v distrobox &>/dev/null; then
@@ -91,8 +91,8 @@ check_doctor_ports() {
   )
 
   local our_ports=""
-  if docker compose -f "$DEVTOOLS_DIR/docker-compose.dev.yml" ps --format '{{.Ports}}' 2>/dev/null | grep -q .; then
-    our_ports="$(docker compose -f "$DEVTOOLS_DIR/docker-compose.dev.yml" ps --format '{{.Ports}}' 2>/dev/null)"
+  if podman compose -f "$DEVTOOLS_DIR/docker-compose.dev.yml" ps --format '{{.Ports}}' 2>/dev/null | grep -q .; then
+    our_ports="$(podman compose -f "$DEVTOOLS_DIR/docker-compose.dev.yml" ps --format '{{.Ports}}' 2>/dev/null)"
   fi
 
   local conflict=0

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -34,7 +34,9 @@ check_doctor_deps() {
     _fail "podman API socket not active (docker-compose can't reach the daemon)"
     echo "       Run: systemctl --user enable --now podman.socket  (or just setup::deps)"
   else
-    _pass "podman $(podman --version | awk '{print $3}') + compose + socket"
+    local compose_ver
+    compose_ver="$(podman compose version 2>/dev/null | grep -i 'Docker Compose version' | sed 's/.*version v\?//; s/[^0-9.].*//')"
+    _pass "podman $(podman --version | awk '{print $3}') + compose ${compose_ver} + socket"
   fi
 
   if ! command -v distrobox &>/dev/null; then

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -30,13 +30,14 @@ check_doctor_deps() {
   elif ! podman compose version &>/dev/null; then
     _fail "podman compose not functional (install docker-compose or upgrade podman)"
     echo "       Run: just setup::deps"
+  elif [ -z "$(_compose_version)" ]; then
+    _fail "podman compose using python podman-compose, not the Go docker-compose provider"
+    echo "       Run: just setup::deps"
   elif [ ! -S "${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock" ]; then
     _fail "podman API socket not active (docker-compose can't reach the daemon)"
     echo "       Run: systemctl --user enable --now podman.socket  (or just setup::deps)"
   else
-    local compose_ver
-    compose_ver="$(podman compose version 2>/dev/null | grep -i 'Docker Compose version' | sed 's/.*version v\?//; s/[^0-9.].*//')"
-    _pass "podman $(podman --version | awk '{print $3}') + compose ${compose_ver} + socket"
+    _pass "podman $(podman --version | awk '{print $3}') + compose $(_compose_version) + socket"
   fi
 
   if ! command -v distrobox &>/dev/null; then

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -1,0 +1,428 @@
+#!/usr/bin/env bash
+# `just bar::launch` entry point.
+
+set -euo pipefail
+
+# bar.just doesn't export these the way repos.just does; default to match.
+: "${REPOS_CONF:=$DEVTOOLS_DIR/repos.conf}"
+: "${REPOS_LOCAL:=$DEVTOOLS_DIR/repos.local.conf}"
+export REPOS_CONF REPOS_LOCAL
+
+source "$DEVTOOLS_DIR/scripts/common.sh"
+source "$DEVTOOLS_DIR/scripts/setup.sh"
+source "$DEVTOOLS_DIR/scripts/repos.sh"
+source "$DEVTOOLS_DIR/scripts/chobby-channel.sh"
+
+require_host
+
+preflight_symlinks() {
+  local game_dir
+  game_dir="$(detect_game_dir 2>/dev/null)" || true
+  if [ -z "$game_dir" ]; then
+    warn "Game directory not detected. Set BAR_DATA_DIR or run 'just setup::init' first."
+    return 0
+  fi
+
+  local missing=()
+  [ -L "$game_dir/games/Beyond-All-Reason.sdd" ] || [ -d "$game_dir/games/Beyond-All-Reason.sdd" ] || missing+=("bar")
+  [ -L "$game_dir/games/BYAR-Chobby.sdd" ]       || [ -d "$game_dir/games/BYAR-Chobby.sdd" ]       || missing+=("chobby")
+  [ -L "$game_dir/engine/local-build" ]          || [ -d "$game_dir/engine/local-build" ]          || missing+=("engine")
+
+  if [ "${#missing[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  info "Devtools symlinks missing: ${missing[*]}"
+  info "Run: just link::create ${missing[*]}"
+  info "(continuing; bar-launch will still work for non-local sources like 'rapid://...:test')"
+}
+
+# Only relevant when chobby drives game selection and a local BAR.sdd exists.
+preflight_chobby_channel() {
+  local data_dir="$1"; shift
+  [ -n "$data_dir" ] || return 0
+
+  if _has_flag --play "$@"; then
+    local play_val
+    play_val="$(_flag_value --play "$@")"
+    [ "$play_val" = "chobby" ] || return 0
+  fi
+
+  if [ ! -L "$data_dir/games/Beyond-All-Reason.sdd" ] && \
+     [ ! -d "$data_dir/games/Beyond-All-Reason.sdd" ]; then
+    return 0
+  fi
+
+  local desired="${BAR_CHOBBY_CHANNEL:-}"
+  if [ -z "$desired" ]; then
+    desired="$(read_env_key BAR_CHOBBY_CHANNEL 2>/dev/null || true)"
+  fi
+
+  local cfg_current widget_current
+  cfg_current="$(_chobby_game_field "$data_dir/chobby_config.json")"
+  widget_current="$(_chobby_widget_game_field "$data_dir")"
+  # IGL_data.lua's saved value overrides chobby_config.json's default.
+  local effective="${widget_current:-$cfg_current}"
+
+  if [ "$desired" = "byar-dev" ]; then
+    if [ "$cfg_current" = "byar-dev" ] && \
+       { [ -z "$widget_current" ] || [ "$widget_current" = "byar-dev" ]; }; then
+      return 0
+    fi
+
+    warn "Chobby channel drifted from byar-dev:"
+    warn "  chobby_config.json:   ${cfg_current:-<unset>}"
+    warn "  IGL_data.lua widget:  ${widget_current:-<unset>}  <-- this is what the dropdown will use"
+    warn "Your local Beyond-All-Reason.sdd edits will NOT load until this is fixed."
+
+    if [ ! -t 0 ]; then
+      warn "(non-interactive shell -- not prompting; run 'just bar::dev-mode' to fix)"
+      return 0
+    fi
+    local ans
+    read -rp "Reset Chobby channel to byar-dev now? [Y/n] " ans
+    if [ -z "$ans" ] || [[ "$ans" =~ ^[Yy] ]]; then
+      set_chobby_channel "$data_dir" "byar-dev"
+      ok "Chobby channel reset to byar-dev"
+    else
+      warn "Continuing without fix; Chobby will load the rapid build for this run."
+    fi
+    return 0
+  fi
+
+  warn "bar::launch found a local Beyond-All-Reason.sdd but Chobby channel = '${effective:-<unset>}', NOT byar-dev."
+  warn "Your local edits will NOT load and dev-mode is OFF."
+  warn "Fix: just bar::dev-mode   (or set BAR_CHOBBY_CHANNEL=byar-dev in .env)"
+}
+
+run_linux() {
+  if ! command -v bar-launch &>/dev/null; then
+    err "bar-launch not on PATH"
+    info "Run 'just setup::init' (pipx-installs the launcher), or run 'pipx ensurepath' if it's already installed."
+    exit 1
+  fi
+  local repo_path
+  repo_path="$(bar_launch_repo_path)"
+
+  # Editable installs pick up .py edits, but a new pinned dep needs a reinstall.
+  local marker="${XDG_STATE_HOME:-$HOME/.local/state}/bar-devtools/bar-launch-installed"
+  local pyproject="$repo_path/pyproject.toml"
+  if [ -f "$pyproject" ] && [ -f "$marker" ] && [ "$pyproject" -nt "$marker" ]; then
+    info "$(basename "$repo_path")/pyproject.toml is newer than the bar-launch install -- reinstalling"
+    ensure_bar_launch_installed "$repo_path" || exit 1
+  fi
+
+  preflight_symlinks
+
+  # Inject flags implied by what's checked out; explicit user args always win.
+  local injected=()
+  local user_args=("$@")
+  local game_dir
+  game_dir="$(detect_game_dir 2>/dev/null)" || true
+  if [ -n "$game_dir" ]; then
+    ensure_devmode_marker "$game_dir"
+    preflight_chobby_channel "$game_dir" "${user_args[@]}"
+    _apply_managed_springsettings "$game_dir/springsettings.cfg" "${user_args[@]}"
+    if [ -e "$game_dir/engine/local-build" ] && ! _has_flag --engine "${user_args[@]}"; then
+      injected+=(--engine local-build)
+    fi
+  fi
+  # Strip our own flags so bar-launch doesn't choke on them.
+  if _has_flag --debug-gl "${user_args[@]}"; then
+    mapfile -d '' user_args < <(_strip_flag --debug-gl "${user_args[@]}")
+  fi
+
+  # Launcher autodetect anchors on cwd; point it at the managed checkout.
+  cd "$repo_path"
+
+  info "Running: bar-launch ${injected[*]:-} ${user_args[*]:-}"
+  exec bar-launch "${injected[@]}" "${user_args[@]}"
+}
+
+# Matches both "--engine X" and "--engine=X" forms.
+_has_flag() {
+  local needle="$1"
+  shift
+  local arg
+  for arg in "$@"; do
+    if [ "$arg" = "$needle" ] || [[ "$arg" == "$needle="* ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Echo a flag's value; "--play X" or "--play=X", last occurrence wins.
+_flag_value() {
+  local needle="$1"; shift
+  local prev="" arg out=""
+  for arg in "$@"; do
+    if [ "$prev" = "$needle" ]; then
+      out="$arg"
+    elif [[ "$arg" == "$needle="* ]]; then
+      out="${arg#*=}"
+    fi
+    prev="$arg"
+  done
+  printf '%s' "$out"
+}
+
+# Drop a boolean flag from "$@", echoing the rest NUL-separated for mapfile.
+_strip_flag() {
+  local needle="$1"; shift
+  local arg
+  for arg in "$@"; do
+    if [ "$arg" = "$needle" ]; then continue; fi
+    printf '%s\0' "$arg"
+  done
+}
+
+# springsettings.cfg keys this launcher owns. Row: <flag> <key> <on> <off>.
+# Every launch resets each key, so a prior launch can't leak settings.
+_MANAGED_SPRINGSETTINGS=(
+  "--debug-gl  DebugGL   1  0"
+  "--debug-gl  LogFlush  1  0"
+)
+
+# Gated on ALLOW_SPRINGSETTINGS_MOD; default off, never touches the cfg
+# unless the user opted in. Without the opt-in, warn once per ignored flag.
+_apply_managed_springsettings() {
+  local cfg="$1"; shift
+
+  local opt_in="${ALLOW_SPRINGSETTINGS_MOD:-0}"
+  case "$opt_in" in
+    1|true|TRUE|yes|YES) ;;
+    *)
+      local entry flag _rest seen=()
+      for entry in "${_MANAGED_SPRINGSETTINGS[@]}"; do
+        read -r flag _rest <<<"$entry"
+        if _has_flag "$flag" "$@"; then
+          local already=0 s
+          for s in "${seen[@]}"; do [ "$s" = "$flag" ] && already=1 && break; done
+          if [ "$already" = "0" ]; then
+            warn "$flag was ignored: ALLOW_SPRINGSETTINGS_MOD is not enabled"
+            info "  This launcher does not modify springsettings.cfg by default."
+            info "  To enable: re-run 'just setup::init' and opt in, or set"
+            info "    ALLOW_SPRINGSETTINGS_MOD=1"
+            info "  in $DEVTOOLS_DIR/.env"
+            seen+=("$flag")
+          fi
+        fi
+      done
+      return 0
+      ;;
+  esac
+
+  if [ -z "$cfg" ]; then
+    local entry flag _rest
+    for entry in "${_MANAGED_SPRINGSETTINGS[@]}"; do
+      read -r flag _rest <<<"$entry"
+      if _has_flag "$flag" "$@"; then
+        warn "$flag requested but no springsettings.cfg path resolved; skipping"
+      fi
+    done
+    return 0
+  fi
+
+  local -A logged_on=()
+  local entry flag key on_v off_v
+  for entry in "${_MANAGED_SPRINGSETTINGS[@]}"; do
+    read -r flag key on_v off_v <<<"$entry"
+    if _has_flag "$flag" "$@"; then
+      if [ -z "${logged_on[$flag]:-}" ]; then
+        info "$flag: applying managed springsettings in $cfg"
+        logged_on[$flag]=1
+      fi
+      springsettings_set "$cfg" "$key" "$on_v" \
+        || warn "Could not set $key=$on_v (override for $flag)"
+    else
+      springsettings_set "$cfg" "$key" "$off_v" >/dev/null 2>&1 || true
+    fi
+  done
+}
+
+run_wsl() {
+  if [ -z "${BAR_DATA_DIR:-}" ]; then
+    err "BAR_DATA_DIR not set. Run 'just setup::init' on WSL2 first."
+    exit 1
+  fi
+
+  ensure_devmode_marker "$BAR_DATA_DIR"
+  preflight_chobby_channel "$BAR_DATA_DIR" "$@"
+  _apply_managed_springsettings "$BAR_DATA_DIR/springsettings.cfg" "$@"
+
+  # Strip --debug-gl: the Windows-side launcher would choke on it.
+  local launch_args=()
+  if _has_flag --debug-gl "$@"; then
+    mapfile -d '' launch_args < <(_strip_flag --debug-gl "$@")
+  else
+    launch_args=("$@")
+  fi
+
+  local shim_wsl="$BAR_DATA_DIR/bin/bar-launch.cmd"
+  if [ ! -f "$shim_wsl" ]; then
+    err "Launcher shim missing at $shim_wsl"
+    info "Regenerate: just bar::regen-shim"
+    exit 1
+  fi
+
+  # --wait-ready: don't launch into a half-mirrored data dir.
+  bash "$DEVTOOLS_DIR/scripts/sync.sh" start --wait-ready \
+    || { err "sync daemon failed to start (see logs: just bar::sync-logs)"; exit 1; }
+
+  local shim_win
+  shim_win="$(wslpath -w "$shim_wsl")"
+
+  # printf, not info: `echo -e` interprets \b in ...\bin\... as backspace.
+  printf '\033[0;34m[info]\033[0m  Launching detached: %s %s\n' "$shim_win" "${launch_args[*]}"
+  printf '\033[0;34m[info]\033[0m  logs:  just bar::log -- -F      (engine infolog)\n'
+  printf '\033[0;34m[info]\033[0m         just bar::sync-logs            (cold-copy log)\n'
+
+  # Plain `cmd.exe /c` -- `start "" /B` gets its "" double-escaped by WSL2
+  # interop. cd /mnt/c gives cmd.exe a drive-letter cwd (avoids UNC warning).
+  ( cd /mnt/c && nohup cmd.exe /c "$shim_win" "${launch_args[@]}" </dev/null >/dev/null 2>&1 & )
+  return 0
+}
+
+stop_wsl() {
+  if ! command -v cmd.exe &>/dev/null; then
+    err "cmd.exe interop unavailable -- can't stop Windows processes from here"
+    return 1
+  fi
+
+  step "Stopping BAR processes"
+  local killed_any=0
+  local proc
+  for proc in spring.exe Beyond-All-Reason.exe; do
+    local out rc
+    out="$(cmd.exe /c "taskkill /F /IM $proc /T" 2>&1)" || rc=$? && rc=${rc:-0}
+    if [ "$rc" -eq 0 ]; then
+      info "  killed: $proc"
+      killed_any=1
+    fi
+  done
+
+  # CIM, not wmic (gone in 24H2+); taskkill, not Stop-Process (under-kills).
+  local pid_cmd='Get-CimInstance Win32_Process -Filter "Name='\''python.exe'\''" | Where-Object { $_.CommandLine -like "*bar_launch*" } | Select-Object -ExpandProperty ProcessId'
+  local pids
+  pids="$(powershell.exe -NoProfile -Command "$pid_cmd" 2>/dev/null | tr -d '\r')"
+  if [ -n "$pids" ]; then
+    local pid
+    while IFS= read -r pid; do
+      [ -z "$pid" ] && continue
+      local rc=0
+      cmd.exe /c "taskkill /F /T /PID $pid" >/dev/null 2>&1 || rc=$?
+      if [ "$rc" = "0" ]; then
+        info "  killed: python.exe (PID $pid, bar_launch)"
+        killed_any=1
+      else
+        warn "  taskkill /PID $pid (bar_launch) returned $rc -- process may still be running"
+      fi
+    done <<<"$pids"
+
+    # CIM cache can lag taskkill -- brief sleep before re-query.
+    sleep 0.3
+    local survivors
+    # awk 'NF' not grep -v '^$': grep returns 1 on no matches and trips set -e.
+    survivors="$(powershell.exe -NoProfile -Command "$pid_cmd" 2>/dev/null | tr -d '\r' | awk 'NF')"
+    if [ -n "$survivors" ]; then
+      warn "bar_launch python.exe survivors after kill:"
+      while IFS= read -r pid; do
+        [ -n "$pid" ] && warn "  PID $pid still running"
+      done <<<"$survivors"
+      warn "  Likely cause: process running as a different user, or a"
+      warn "  protection policy is blocking taskkill. Try from an elevated"
+      warn "  PowerShell:  taskkill /F /T /PID <pid>"
+    fi
+  fi
+
+  if [ -n "${BAR_DATA_DIR:-}" ] \
+     && [ -f "$BAR_DATA_DIR/.bar-launch/sync.pid" ]; then
+    bash "$DEVTOOLS_DIR/scripts/sync.sh" stop \
+      && killed_any=1 \
+      || warn "sync daemon stop returned non-zero (see $BAR_DATA_DIR/.bar-launch/sync.log)"
+  fi
+
+  if [ "$killed_any" = "0" ]; then
+    info "no BAR processes were running"
+  else
+    ok "BAR processes stopped"
+  fi
+}
+
+stop_linux() {
+  step "Stopping BAR processes"
+  local killed_any=0
+
+  # -f matches the full cmdline so we don't hit unrelated Pythons.
+  local pids
+  pids="$(pgrep -f 'python.* -m bar_launch' 2>/dev/null | awk 'NF')"
+  if [ -n "$pids" ]; then
+    while IFS= read -r pid; do
+      [ -z "$pid" ] && continue
+      if kill -TERM "$pid" 2>/dev/null; then
+        info "  killed: python -m bar_launch (PID $pid)"
+        killed_any=1
+      fi
+    done <<<"$pids"
+  fi
+
+  # Scope spring kills to binaries running out of our game dir.
+  local game_dir
+  game_dir="$(detect_game_dir 2>/dev/null)" || true
+  if [ -n "$game_dir" ]; then
+    local spring_pids
+    spring_pids="$(pgrep -x 'spring|spring-headless|spring-dedicated' 2>/dev/null | awk 'NF')"
+    if [ -n "$spring_pids" ]; then
+      while IFS= read -r pid; do
+        [ -z "$pid" ] && continue
+        local exe
+        exe="$(readlink "/proc/$pid/exe" 2>/dev/null)" || continue
+        case "$exe" in
+          "$game_dir"/*)
+            if kill -TERM "$pid" 2>/dev/null; then
+              info "  killed: $(basename "$exe") (PID $pid, $game_dir)"
+              killed_any=1
+            fi
+            ;;
+        esac
+      done <<<"$spring_pids"
+    fi
+  fi
+
+  # Anything alive after a brief grace period gets SIGKILL.
+  sleep 0.3
+  local survivors
+  survivors="$(pgrep -f 'python.* -m bar_launch' 2>/dev/null | awk 'NF')"
+  if [ -n "$survivors" ]; then
+    while IFS= read -r pid; do
+      [ -z "$pid" ] && continue
+      if kill -KILL "$pid" 2>/dev/null; then
+        warn "  SIGKILL'd surviving python -m bar_launch (PID $pid)"
+      else
+        warn "  PID $pid (bar_launch) survived SIGTERM and SIGKILL failed"
+      fi
+    done <<<"$survivors"
+  fi
+
+  if [ "$killed_any" = "0" ]; then
+    info "no BAR processes were running"
+  else
+    ok "BAR processes stopped"
+  fi
+}
+
+case "${BAR_LAUNCH_MODE:-launch}" in
+  stop)
+    if is_wsl; then stop_wsl; else stop_linux; fi
+    exit $?
+    ;;
+  launch|*)
+    if is_wsl; then
+      run_wsl "$@"
+      exit $?
+    else
+      run_linux "$@"
+    fi
+    ;;
+esac

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -80,7 +80,7 @@ preflight_chobby_channel() {
       return 0
     fi
     local ans
-    read -rp "Reset Chobby channel to byar-dev now? [Y/n] " ans
+    read -rp "Reset Chobby channel to dev mode (byar-dev) now? [Y/n] " ans
     if [ -z "$ans" ] || [[ "$ans" =~ ^[Yy] ]]; then
       set_chobby_channel "$data_dir" "byar-dev"
       ok "Chobby channel reset to byar-dev"
@@ -392,9 +392,9 @@ stop_linux() {
 
   # Anything alive after a brief grace period gets SIGKILL.
   sleep 0.3
-  local survivors
-  survivors="$(pgrep -f 'python.* -m bar_launch' 2>/dev/null | awk 'NF')"
-  if [ -n "$survivors" ]; then
+  local python_bar_launch_survivors
+  python_bar_launch_survivors="$(pgrep -f 'python.* -m bar_launch' 2>/dev/null | awk 'NF')"
+  if [ -n "$python_bar_launch_survivors" ]; then
     while IFS= read -r pid; do
       [ -z "$pid" ] && continue
       if kill -KILL "$pid" 2>/dev/null; then
@@ -402,7 +402,7 @@ stop_linux() {
       else
         warn "  PID $pid (bar_launch) survived SIGTERM and SIGKILL failed"
       fi
-    done <<<"$survivors"
+    done <<<"$python_bar_launch_survivors"
   fi
 
   if [ "$killed_any" = "0" ]; then

--- a/scripts/repos.sh
+++ b/scripts/repos.sh
@@ -17,12 +17,13 @@ _apply_protocol() {
 
 load_repos_conf() {
   REPO_DIRS=(); REPO_URLS=(); REPO_UPSTREAM_URLS=(); REPO_BRANCHES=(); REPO_FEATURES=(); REPO_LOCAL_PATHS=()
-  local -A seen=() base_urls=()
+  local -A seen=() base_urls=() seen_in_file=() directive_seen=()
   local local_root="" protocol=""
 
   _parse_conf() {
     local file="$1" is_base="$2"
     [ -f "$file" ] || return 0
+    seen_in_file=(); directive_seen=()
     while IFS= read -r line || [ -n "$line" ]; do
       line="${line%$'\r'}"
       line="${line%%#*}"
@@ -35,8 +36,10 @@ load_repos_conf() {
         case "$key" in
           local_root) local_root="${val/#\~/$HOME}" ;;
           protocol)   protocol="$val" ;;
-          *)          warn "Unknown directive in $file: @$key" ;;
+          *)          warn "Unknown directive in $file: @$key"; continue ;;
         esac
+        [ -n "${directive_seen[$key]:-}" ] && warn "  ${file##*/}: @$key set more than once -- using '$val'"
+        directive_seen[$key]=1
         continue
       fi
 
@@ -44,6 +47,7 @@ load_repos_conf() {
       read -r dir url branch feature local_path <<< "$line"
       [ -z "$dir" ] && continue
       local_path="${local_path/#\~/$HOME}"
+      local raw_url="$url" raw_branch="$branch" raw_feature="$feature" raw_local_path="$local_path"
 
       # repos.conf URL is canonical; repos.local.conf overrides per blank column
       if [ "$is_base" = "1" ] && [ -n "$url" ]; then
@@ -59,6 +63,18 @@ load_repos_conf() {
       feature="${feature:-$prev_feature}"
       local_path="${local_path:-$prev_local_path}"
       [ -z "$url" ] && continue
+
+      if [ -n "${seen_in_file[$dir]:-}" ]; then
+        warn "  ${file##*/}: duplicate entry for '$dir' -- using the last one"
+      elif [ -n "${seen[$dir]:-}" ]; then
+        local changes=""
+        [ -n "$raw_url" ]        && [ "$raw_url" != "$prev_url" ]               && changes+=" url=$raw_url"
+        [ -n "$raw_branch" ]     && [ "$raw_branch" != "$prev_branch" ]         && changes+=" branch=$prev_branch->$raw_branch"
+        [ -n "$raw_feature" ]    && [ "$raw_feature" != "$prev_feature" ]       && changes+=" feature=$raw_feature"
+        [ -n "$raw_local_path" ] && [ "$raw_local_path" != "$prev_local_path" ] && changes+=" local_path=$raw_local_path"
+        [ -n "$changes" ] && info "  $dir: local override --$changes"
+      fi
+      seen_in_file[$dir]=1
 
       seen[$dir]="$url|$branch|$feature|$local_path"
     done < "$file"

--- a/scripts/repos.sh
+++ b/scripts/repos.sh
@@ -1,69 +1,255 @@
 #!/usr/bin/env bash
-# Repository management helpers.
+# Repository management helpers. Source scripts/common.sh before this file.
 # Expects: DEVTOOLS_DIR, REPOS_CONF, REPOS_LOCAL (exported by Justfile)
-# Source scripts/common.sh before this file.
 
-declare -a REPO_DIRS=() REPO_URLS=() REPO_BRANCHES=() REPO_GROUPS=() REPO_LOCAL_PATHS=()
+declare -a REPO_DIRS=() REPO_URLS=() REPO_UPSTREAM_URLS=() REPO_BRANCHES=() REPO_FEATURES=() REPO_LOCAL_PATHS=()
+
+_apply_protocol() {
+  local url="$1" protocol="$2"
+  if [ "$protocol" = "ssh" ] && [[ "$url" =~ ^https://github\.com/(.+)$ ]]; then
+    echo "git@github.com:${BASH_REMATCH[1]}"
+  elif [ "$protocol" = "https" ] && [[ "$url" =~ ^git@github\.com:(.+)$ ]]; then
+    echo "https://github.com/${BASH_REMATCH[1]}"
+  else
+    echo "$url"
+  fi
+}
 
 load_repos_conf() {
-  REPO_DIRS=(); REPO_URLS=(); REPO_BRANCHES=(); REPO_GROUPS=(); REPO_LOCAL_PATHS=()
-  local -A seen=()
+  REPO_DIRS=(); REPO_URLS=(); REPO_UPSTREAM_URLS=(); REPO_BRANCHES=(); REPO_FEATURES=(); REPO_LOCAL_PATHS=()
+  local -A seen=() base_urls=()
+  local local_root="" protocol=""
 
   _parse_conf() {
-    local file="$1"
+    local file="$1" is_base="$2"
     [ -f "$file" ] || return 0
     while IFS= read -r line || [ -n "$line" ]; do
+      line="${line%$'\r'}"
       line="${line%%#*}"
       line="$(echo "$line" | xargs 2>/dev/null || true)"
       [ -z "$line" ] && continue
-      local dir url branch group local_path
-      read -r dir url branch group local_path <<< "$line"
-      [ -z "$dir" ] || [ -z "$url" ] && continue
-      branch="${branch:-master}"
-      group="${group:-extra}"
+
+      # directive lines: @key value
+      if [[ "$line" =~ ^@([a-z_]+)[[:space:]]+(.+)$ ]]; then
+        local key="${BASH_REMATCH[1]}" val="${BASH_REMATCH[2]}"
+        case "$key" in
+          local_root) local_root="${val/#\~/$HOME}" ;;
+          protocol)   protocol="$val" ;;
+          *)          warn "Unknown directive in $file: @$key" ;;
+        esac
+        continue
+      fi
+
+      local dir url branch feature local_path
+      read -r dir url branch feature local_path <<< "$line"
+      [ -z "$dir" ] && continue
       local_path="${local_path/#\~/$HOME}"
-      seen[$dir]="$url $branch $group $local_path"
+
+      # repos.conf URL is canonical; repos.local.conf overrides per blank column
+      if [ "$is_base" = "1" ] && [ -n "$url" ]; then
+        base_urls[$dir]="$url"
+      fi
+
+      local prev_url="" prev_branch="" prev_feature="" prev_local_path=""
+      if [ -n "${seen[$dir]:-}" ]; then
+        IFS='|' read -r prev_url prev_branch prev_feature prev_local_path <<< "${seen[$dir]}"
+      fi
+      url="${url:-$prev_url}"
+      branch="${branch:-${prev_branch:-master}}"
+      feature="${feature:-$prev_feature}"
+      local_path="${local_path:-$prev_local_path}"
+      [ -z "$url" ] && continue
+
+      seen[$dir]="$url|$branch|$feature|$local_path"
     done < "$file"
   }
 
-  _parse_conf "$REPOS_CONF"
-  _parse_conf "$REPOS_LOCAL"
+  _parse_conf "$REPOS_CONF" 1
+  _parse_conf "$REPOS_LOCAL" 0
 
   local dir
   for dir in "${!seen[@]}"; do
-    local url branch group local_path
-    read -r url branch group local_path <<< "${seen[$dir]}"
+    local url branch feature local_path upstream_url=""
+    IFS='|' read -r url branch feature local_path <<< "${seen[$dir]}"
+
+    url="$(_apply_protocol "$url" "$protocol")"
+    if [ -n "${base_urls[$dir]:-}" ]; then
+      local base_url
+      base_url="$(_apply_protocol "${base_urls[$dir]}" "$protocol")"
+      # only a separate `upstream` when canonical differs from origin
+      if [ "$base_url" != "$url" ]; then
+        upstream_url="$base_url"
+      fi
+    fi
+
+    if [ -z "$local_path" ] && [ -n "$local_root" ]; then
+      local_path="$local_root/$dir"
+    fi
+
     REPO_DIRS+=("$dir")
     REPO_URLS+=("$url")
+    REPO_UPSTREAM_URLS+=("$upstream_url")
     REPO_BRANCHES+=("$branch")
-    REPO_GROUPS+=("$group")
+    REPO_FEATURES+=("$feature")
     REPO_LOCAL_PATHS+=("$local_path")
   done
 }
 
-clone_or_update_repo() {
-  local dir="$1" url="$2" branch="$3" local_path="${4:-}" target="$DEVTOOLS_DIR/$dir"
+# warn (don't touch) when an existing repo's remotes don't match config
+verify_remotes() {
+  local dir="$1" target="$2" url="$3" upstream_url="$4"
+  [ -d "$target/.git" ] || return 0
 
-  if [ -n "$local_path" ]; then
-    if [ ! -d "$local_path" ]; then
-      warn "  ${dir}: local path does not exist: ${local_path}"
-      return 1
+  local origin_url upstream_remote_url
+  origin_url="$(git -C "$target" remote get-url origin 2>/dev/null || true)"
+  upstream_remote_url="$(git -C "$target" remote get-url upstream 2>/dev/null || true)"
+
+  local complaint=""
+  if [ -n "$upstream_url" ]; then
+    if [ "$origin_url" != "$url" ] || [ "$upstream_remote_url" != "$upstream_url" ]; then
+      complaint="expected origin=${url}, upstream=${upstream_url}"
     fi
+  else
+    # tolerate the legacy layout where origin (and only origin) is canonical
+    if [ -n "$upstream_remote_url" ] && [ "$upstream_remote_url" != "$url" ]; then
+      complaint="expected upstream=${url}"
+    elif [ -z "$upstream_remote_url" ] && [ -n "$origin_url" ] && [ "$origin_url" != "$url" ]; then
+      complaint="expected upstream=${url}"
+    fi
+  fi
+
+  if [ -n "$complaint" ]; then
+    warn "  ${dir}: remotes don't match config (${complaint})"
+    [ -n "$origin_url" ]          && warn "    origin   = ${origin_url}"
+    [ -n "$upstream_remote_url" ] && warn "    upstream = ${upstream_remote_url}"
+    warn "    run \`just repos::fixup\` to normalize"
+  fi
+}
+
+fetch_all_remotes() {
+  local dir="$1" target="$2"
+  local remote
+  while read -r remote; do
+    [ -z "$remote" ] && continue
+    git -C "$target" fetch "$remote" --tags --quiet 2>/dev/null \
+      || warn "  ${dir}: fetch ${remote} failed (offline or auth?)"
+  done < <(git -C "$target" remote)
+}
+
+# fresh checkouts only
+do_clone() {
+  local dir="$1" url="$2" branch="$3" upstream_url="$4" target="$5"
+  local origin_name="origin"
+  # no fork override -> canonical is our only remote, name it `upstream`
+  [ -z "$upstream_url" ] && origin_name="upstream"
+
+  info "  ${dir}: cloning ${url} as ${origin_name} (branch: ${branch})..."
+  mkdir -p "$(dirname "$target")"
+  if ! git clone --origin "$origin_name" --recurse-submodules --branch "$branch" "$url" "$target" 2>&1 | sed 's/^/    /'; then
+    err "  ${dir}: clone failed (check URL / SSH access)"
+    return 1
+  fi
+  if [ -n "$upstream_url" ]; then
+    info "  ${dir}: adding upstream -> ${upstream_url}"
+    git -C "$target" remote add upstream "$upstream_url"
+    git -C "$target" fetch upstream --tags --quiet 2>/dev/null \
+      || warn "  ${dir}: upstream fetch failed (offline or auth?)"
+  fi
+}
+
+# normalize an existing repo's remotes; warns and skips unrecognized layouts
+fixup_remotes() {
+  local dir="$1" target="$2" url="$3" upstream_url="$4"
+  [ -d "$target/.git" ] || return 0
+
+  local origin_url upstream_remote_url
+  origin_url="$(git -C "$target" remote get-url origin 2>/dev/null || true)"
+  upstream_remote_url="$(git -C "$target" remote get-url upstream 2>/dev/null || true)"
+
+  if [ -n "$upstream_url" ]; then
+    if [ "$origin_url" = "$url" ] && [ "$upstream_remote_url" = "$upstream_url" ]; then
+      ok "  ${dir}: already normalized"
+      return 0
+    fi
+    if [ "$origin_url" = "$url" ] && [ -z "$upstream_remote_url" ]; then
+      info "  ${dir}: adding upstream=${upstream_url}"
+      git -C "$target" remote add upstream "$upstream_url"
+    elif [ "$origin_url" = "$upstream_url" ] && [ -z "$upstream_remote_url" ]; then
+      info "  ${dir}: renaming origin -> upstream and adding origin=${url}"
+      git -C "$target" remote rename origin upstream
+      git -C "$target" remote add origin "$url"
+    elif [ "$origin_url" = "$upstream_url" ] && [ "$upstream_remote_url" = "$url" ]; then
+      info "  ${dir}: swapping inverted origin/upstream URLs"
+      git -C "$target" remote set-url origin "$url"
+      git -C "$target" remote set-url upstream "$upstream_url"
+    else
+      warn "  ${dir}: unrecognized remote layout, skipping"
+      [ -n "$origin_url" ]          && warn "    origin   = ${origin_url}"
+      [ -n "$upstream_remote_url" ] && warn "    upstream = ${upstream_remote_url}"
+      warn "    expected origin=${url}, upstream=${upstream_url}"
+      return 0
+    fi
+    git -C "$target" fetch upstream --tags --quiet 2>/dev/null \
+      || warn "  ${dir}: upstream fetch failed (offline or auth?)"
+  else
+    if [ "$upstream_remote_url" = "$url" ]; then
+      ok "  ${dir}: already normalized"
+      return 0
+    fi
+    if [ -z "$upstream_remote_url" ] && [ "$origin_url" = "$url" ]; then
+      info "  ${dir}: renaming origin -> upstream"
+      git -C "$target" remote rename origin upstream
+    else
+      warn "  ${dir}: unrecognized remote layout, skipping"
+      [ -n "$origin_url" ]          && warn "    origin   = ${origin_url}"
+      [ -n "$upstream_remote_url" ] && warn "    upstream = ${upstream_remote_url}"
+      warn "    expected upstream=${url}"
+      return 0
+    fi
+    git -C "$target" fetch upstream --tags --quiet 2>/dev/null \
+      || warn "  ${dir}: upstream fetch failed (offline or auth?)"
+  fi
+}
+
+clone_or_update_repo() {
+  local dir="$1" url="$2" branch="$3" upstream_url="$4" local_path="${5:-}" target="$DEVTOOLS_DIR/$dir"
+
+  # config wants a symlink: workspace slot -> external checkout
+  if [ -n "$local_path" ]; then
+    mkdir -p "$(dirname "$local_path")"
+
+    if [ ! -L "$target" ] && [ -d "$target" ]; then
+      if [ -d "$target/.git" ] && [ ! -d "$local_path" ]; then
+        # workspace copy is the repo and canonical slot is free: promote it
+        info "  ${dir}: moving workspace checkout -> ${local_path}"
+        mv "$target" "$local_path" || { err "  ${dir}: move failed"; return 1; }
+      else
+        # move aside so we never delete user data
+        local backup="$DEVTOOLS_DIR/.backups/${dir}-$(date +%Y%m%d-%H%M%S)"
+        warn "  ${dir}: workspace has a real directory where config wants a symlink"
+        info "  ${dir}: backing it up -> ${backup}"
+        mkdir -p "$DEVTOOLS_DIR/.backups"
+        mv "$target" "$backup" || { err "  ${dir}: backup move failed"; return 1; }
+      fi
+    fi
+
+    if [ ! -d "$local_path" ]; then
+      do_clone "$dir" "$url" "$branch" "$upstream_url" "$local_path" || return 1
+    else
+      verify_remotes "$dir" "$local_path" "$url" "$upstream_url"
+    fi
+
     if [ -L "$target" ]; then
       local current_link
       current_link="$(readlink "$target")"
       if [ "$current_link" = "$local_path" ]; then
         ok "  ${dir}: linked -> ${local_path}"
       else
-        warn "  ${dir}: symlink points to ${current_link}, config says ${local_path}"
-        info "  ${dir}: updating symlink..."
+        info "  ${dir}: repointing symlink (${current_link} -> ${local_path})"
         rm "$target"
         ln -s "$local_path" "$target"
         ok "  ${dir}: linked -> ${local_path}"
       fi
-    elif [ -d "$target" ]; then
-      warn "  ${dir}: exists as a real directory but config says link to ${local_path}"
-      warn "  ${dir}: remove it manually to use the local path"
     else
       ln -s "$local_path" "$target"
       ok "  ${dir}: linked -> ${local_path}"
@@ -71,29 +257,36 @@ clone_or_update_repo() {
     return 0
   fi
 
-  if [ -d "$target/.git" ]; then
-    local current_url
-    current_url="$(git -C "$target" remote get-url origin 2>/dev/null || true)"
-    if [ "$current_url" != "$url" ] && [ -n "$current_url" ]; then
-      warn "  ${dir}: origin is ${current_url}"
-      warn "  ${dir}: config says ${url}"
-      warn "  ${dir}: add to repos.local.conf to set your preferred remote"
+  # config wants an in-place clone: workspace slot is the checkout
+  if [ -L "$target" ]; then
+    local dest
+    dest="$(readlink "$target")"
+    warn "  ${dir}: workspace is a symlink but config says clone-in-place"
+    rm "$target"
+    if [ -d "$dest/.git" ]; then
+      info "  ${dir}: moving ${dest} into the workspace"
+      mv "$dest" "$target" || { err "  ${dir}: move failed"; return 1; }
     fi
+  fi
+
+  if [ -d "$target/.git" ]; then
+    verify_remotes "$dir" "$target" "$url" "$upstream_url"
     info "  ${dir}: fetching latest..."
-    git -C "$target" fetch origin --quiet 2>/dev/null || warn "  ${dir}: fetch failed (offline?)"
+    fetch_all_remotes "$dir" "$target"
+    git -C "$target" submodule update --init --recursive --quiet 2>/dev/null \
+      || warn "  ${dir}: submodule sync failed (offline or auth?)"
     local current_branch
     current_branch="$(git -C "$target" branch --show-current 2>/dev/null)"
     if [ -n "$current_branch" ] && [ "$current_branch" != "$branch" ]; then
       info "  ${dir}: on branch '${current_branch}' (config says '${branch}')"
     fi
   else
-    info "  ${dir}: cloning ${url} (branch: ${branch})..."
-    git clone --branch "$branch" "$url" "$target" 2>&1 | sed 's/^/    /'
+    do_clone "$dir" "$url" "$branch" "$upstream_url" "$target"
   fi
 }
 
 cmd_clone() {
-  local group_filter="${1:-all}"
+  local feature_filter="${1:-all}"
   load_repos_conf
 
   if [ "${#REPO_DIRS[@]}" -eq 0 ]; then
@@ -113,23 +306,24 @@ cmd_clone() {
   for i in "${!REPO_DIRS[@]}"; do
     local dir="${REPO_DIRS[$i]}"
     local url="${REPO_URLS[$i]}"
+    local upstream_url="${REPO_UPSTREAM_URLS[$i]}"
     local branch="${REPO_BRANCHES[$i]}"
-    local group="${REPO_GROUPS[$i]}"
+    local feature="${REPO_FEATURES[$i]}"
     local local_path="${REPO_LOCAL_PATHS[$i]}"
 
-    if [ "$group_filter" != "all" ] && [ "$group" != "$group_filter" ]; then
+    if [ "$feature_filter" != "all" ] && ! features_include "$feature" "$feature_filter"; then
       skipped=$((skipped + 1))
       continue
     fi
 
     if [ -n "$local_path" ]; then
-      clone_or_update_repo "$dir" "$url" "$branch" "$local_path"
+      clone_or_update_repo "$dir" "$url" "$branch" "$upstream_url" "$local_path"
       linked=$((linked + 1))
     elif [ -d "$DEVTOOLS_DIR/$dir/.git" ]; then
-      clone_or_update_repo "$dir" "$url" "$branch"
+      clone_or_update_repo "$dir" "$url" "$branch" "$upstream_url"
       updated=$((updated + 1))
     else
-      clone_or_update_repo "$dir" "$url" "$branch"
+      clone_or_update_repo "$dir" "$url" "$branch" "$upstream_url"
       cloned=$((cloned + 1))
     fi
   done
@@ -145,13 +339,13 @@ cmd_repos() {
 
   echo -e "${BOLD}=== Repository Status ===${NC}"
   echo ""
-  printf "  ${DIM}%-24s %-8s %-18s %s${NC}\n" "DIRECTORY" "GROUP" "BRANCH" "STATUS"
+  printf "  ${DIM}%-24s %-22s %-18s %s${NC}\n" "DIRECTORY" "FEATURE" "BRANCH" "STATUS"
   echo "  $(printf '%.0s-' {1..80})"
 
   local i
   for i in "${!REPO_DIRS[@]}"; do
     local dir="${REPO_DIRS[$i]}"
-    local group="${REPO_GROUPS[$i]}"
+    local feature="${REPO_FEATURES[$i]:--}"
     local target="$DEVTOOLS_DIR/$dir"
 
     local status current_branch
@@ -186,7 +380,7 @@ cmd_repos() {
       current_branch="-"
     fi
 
-    printf "  %-24s %-8s %-18s %b\n" "$dir" "$group" "$current_branch" "$status"
+    printf "  %-24s %-22s %-18s %b\n" "$dir" "$feature" "$current_branch" "$status"
   done
   echo ""
 }
@@ -205,8 +399,33 @@ cmd_update() {
       branch="$(git -C "$target" branch --show-current 2>/dev/null)"
       info "${dir}: pulling ${branch}..."
       git -C "$target" pull --ff-only 2>&1 | sed 's/^/    /' || warn "  ${dir}: pull failed (conflicts?)"
+      fetch_all_remotes "$dir" "$target"
     fi
   done
   echo ""
   ok "Update complete."
+}
+
+cmd_fixup() {
+  load_repos_conf
+
+  echo -e "${BOLD}=== Normalizing Repository Remotes ===${NC}"
+  echo ""
+  info "Target: origin = fork (repos.local.conf), upstream = canonical (repos.conf)."
+  info "Repos with no fork: single remote \`upstream\` = canonical."
+  echo ""
+
+  local i
+  for i in "${!REPO_DIRS[@]}"; do
+    local dir="${REPO_DIRS[$i]}"
+    local url="${REPO_URLS[$i]}"
+    local upstream_url="${REPO_UPSTREAM_URLS[$i]}"
+    local local_path="${REPO_LOCAL_PATHS[$i]}"
+    local repo_path="$DEVTOOLS_DIR/$dir"
+    [ -n "$local_path" ] && repo_path="$local_path"
+    [ -d "$repo_path/.git" ] || continue
+    fixup_remotes "$dir" "$repo_path" "$url" "$upstream_url"
+  done
+  echo ""
+  ok "Fixup complete."
 }

--- a/scripts/repos.sh
+++ b/scripts/repos.sh
@@ -122,7 +122,7 @@ verify_remotes() {
     warn "  ${dir}: remotes don't match config (${complaint})"
     [ -n "$origin_url" ]          && warn "    origin   = ${origin_url}"
     [ -n "$upstream_remote_url" ] && warn "    upstream = ${upstream_remote_url}"
-    warn "    run \`just repos::fixup\` to normalize"
+    warn "    run \`just repos::standardize-remotes\` to normalize"
   fi
 }
 
@@ -406,7 +406,7 @@ cmd_update() {
   ok "Update complete."
 }
 
-cmd_fixup() {
+cmd_standardize_remotes() {
   load_repos_conf
 
   echo -e "${BOLD}=== Normalizing Repository Remotes ===${NC}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1835,7 +1835,11 @@ cmd_init() {
   else
     cmd_setup_bar_launch
   fi
-  recap "bar-launch venv" ok "ready"
+  if [ $? -eq 0 ]; then
+    recap "bar-launch venv" ok "ready"
+  else
+    recap "bar-launch venv" warn "failed -- see output above"
+  fi
   echo ""
 
   step "8/8  Deferred module apply (editor, etc.)"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -209,6 +209,7 @@ ensure_wsl_setup() {
   fi
 
   ok "WSL2 environment ready (systemd active, / is a shared mount)"
+  wsl_virtiofs_hint
   echo ""
 }
 
@@ -293,19 +294,6 @@ install_distrobox_upstream() {
     | sudo sh -s -- --prefix /usr/local
   hash -r
   ok "distrobox installed: $(/usr/local/bin/distrobox --version 2>/dev/null | awk '{print $NF}')"
-}
-
-_ver_ge() {
-  local IFS=.
-  local -a a=($1) b=($2)
-  local i max=${#a[@]}
-  [ "${#b[@]}" -gt "$max" ] && max=${#b[@]}
-  for ((i=0; i<max; i++)); do
-    local ai=${a[i]:-0} bi=${b[i]:-0}
-    if (( 10#$ai > 10#$bi )); then return 0; fi
-    if (( 10#$ai < 10#$bi )); then return 1; fi
-  done
-  return 0
 }
 
 # Docker Compose v5+ from upstream releases. Compose v2.x defaults to bake/BuildKit, which podman

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -358,6 +358,10 @@ cmd_install_deps() {
   if ! command -v podman &>/dev/null; then
     missing+=("container-runtime")
   fi
+  # curl drives the upstream distrobox/compose installers below; ensure it first.
+  if ! command -v curl &>/dev/null; then
+    missing+=("curl")
+  fi
   # Debian gets compose from install_compose_upstream below, never from apt.
   if [ "$distro" != "debian" ] && ! command -v docker-compose &>/dev/null; then
     missing+=("container-compose")

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2099,6 +2099,46 @@ cmd_link() {
   ok "Linked $target: $link_path -> $source_path"
 }
 
+cmd_unlink() {
+  local target="${1:-all}"
+  local game_dir
+  game_dir="$(detect_game_dir 2>/dev/null)" || true
+  if [ -z "$game_dir" ]; then
+    err "Game directory not found. Set BAR_DATA_DIR env var or install BAR to the default location."
+    exit 1
+  fi
+
+  local -A link_map=(
+    [engine]="$game_dir/engine/local-build"
+    [chobby]="$game_dir/games/BYAR-Chobby.sdd"
+    [bar]="$game_dir/games/Beyond-All-Reason.sdd"
+  )
+
+  local -a targets
+  if [ "$target" = "all" ]; then
+    targets=(engine chobby bar)
+  elif [ -n "${link_map[$target]:-}" ]; then
+    targets=("$target")
+  else
+    err "Unknown link target: $target"
+    echo "  Valid targets: engine, chobby, bar, all"
+    exit 1
+  fi
+
+  local name link_path
+  for name in "${targets[@]}"; do
+    link_path="${link_map[$name]}"
+    if [ -L "$link_path" ]; then
+      rm "$link_path"
+      ok "Unlinked $name: removed symlink $link_path"
+    elif [ -e "$link_path" ]; then
+      warn "$name: $link_path exists but isn't a Devtools symlink -- leaving it."
+    else
+      info "$name: not linked."
+    fi
+  done
+}
+
 # Load the setup module registry. MUST run after every setup.sh helper is defined.
 # shellcheck source=scripts/setup/_lib.sh
 source "$DEVTOOLS_DIR/scripts/setup/_lib.sh"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -358,10 +358,6 @@ cmd_install_deps() {
   if ! command -v podman &>/dev/null; then
     missing+=("container-runtime")
   fi
-  # curl drives the upstream distrobox/compose installers below; ensure it first.
-  if ! command -v curl &>/dev/null; then
-    missing+=("curl")
-  fi
   # Debian gets compose from install_compose_upstream below, never from apt.
   if [ "$distro" != "debian" ] && ! command -v docker-compose &>/dev/null; then
     missing+=("container-compose")

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -102,9 +102,7 @@ check_podman() {
     info "  Run: just setup::deps"
     return 1
   fi
-  local compose_ver
-  compose_ver="$(podman compose version 2>/dev/null | grep -i 'Docker Compose version' | sed 's/.*version v\?//; s/[^0-9.].*//')"
-  ok "podman $(podman --version | awk '{print $3}') + compose ${compose_ver} + socket detected"
+  ok "podman $(podman --version | awk '{print $3}') + compose $(_compose_version) + socket detected"
 }
 
 check_distrobox() {
@@ -303,15 +301,11 @@ install_distrobox_upstream() {
 install_compose_upstream() {
   local min_version="5.0.0"
   local pin_version="5.1.3"
-  local current=""
-  local compose_out
-  compose_out="$(podman compose version 2>/dev/null)" || true
-  if [ -n "$compose_out" ]; then
-    current="$(echo "$compose_out" | grep -i 'Docker Compose version' | sed 's/.*version v\?//; s/[^0-9.].*//')"
-    if [ -n "$current" ] && _ver_ge "$current" "$min_version"; then
-      ok "podman compose delegates to Docker Compose ${current} (>= ${min_version})"
-      return 0
-    fi
+  local current
+  current="$(_compose_version)"
+  if [ -n "$current" ] && _ver_ge "$current" "$min_version"; then
+    ok "podman compose delegates to Docker Compose ${current} (>= ${min_version})"
+    return 0
   fi
 
   local arch

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -90,9 +90,9 @@ check_podman() {
     info "  Try a fresh init:  podman system reset  (destroys local images)"
     return 1
   fi
-  # podman compose delegates to the buggy python podman-compose unless the Go binary is present.
-  if ! command -v docker-compose &>/dev/null; then
-    err "docker-compose not installed (podman compose dispatcher needs it as provider)."
+  # podman compose delegates to the python podman-compose unless a Go docker-compose provider is present.
+  if ! podman compose version &>/dev/null; then
+    err "podman compose not functional (install docker-compose or upgrade podman)."
     info "  Run: just setup::deps"
     return 1
   fi
@@ -102,7 +102,9 @@ check_podman() {
     info "  Run: just setup::deps"
     return 1
   fi
-  ok "podman $(podman --version | awk '{print $3}') + docker-compose $(docker-compose version --short 2>/dev/null) + socket detected"
+  local compose_ver
+  compose_ver="$(podman compose version 2>/dev/null | grep -i 'Docker Compose version' | sed 's/.*version v\?//; s/[^0-9.].*//')"
+  ok "podman $(podman --version | awk '{print $3}') + compose ${compose_ver} + socket detected"
 }
 
 check_distrobox() {
@@ -302,12 +304,14 @@ install_compose_upstream() {
   local min_version="5.0.0"
   local pin_version="5.1.3"
   local current=""
-  if command -v docker-compose &>/dev/null; then
-    current="$(docker-compose version --short 2>/dev/null | sed 's/^v//')"
-  fi
-  if [ -n "$current" ] && _ver_ge "$current" "$min_version"; then
-    ok "docker-compose ${current} already installed (>= ${min_version})"
-    return 0
+  local compose_out
+  compose_out="$(podman compose version 2>/dev/null)" || true
+  if [ -n "$compose_out" ]; then
+    current="$(echo "$compose_out" | grep -i 'Docker Compose version' | sed 's/.*version v\?//; s/[^0-9.].*//')"
+    if [ -n "$current" ] && _ver_ge "$current" "$min_version"; then
+      ok "podman compose delegates to Docker Compose ${current} (>= ${min_version})"
+      return 0
+    fi
   fi
 
   local arch

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -282,8 +282,10 @@ ensure_windows_python() {
 
 # Install distrobox from upstream; need >= 1.8.2.3 for the chpasswd fix against shadow-utils 4.13+.
 install_distrobox_upstream() {
-  local current
-  current="$(/usr/local/bin/distrobox --version 2>/dev/null | awk '{print $NF}')"
+  local current=""
+  if [ -x /usr/local/bin/distrobox ]; then
+    current="$(/usr/local/bin/distrobox --version 2>/dev/null | awk '{print $NF}')"
+  fi
   if [ -n "$current" ] && _ver_ge "$current" "1.8.2.3"; then
     ok "distrobox already up-to-date at /usr/local/bin: $current"
     return 0
@@ -302,7 +304,7 @@ install_compose_upstream() {
   local min_version="5.0.0"
   local pin_version="5.1.3"
   local current
-  current="$(_compose_version)"
+  current="$(_compose_version)" || true
   if [ -n "$current" ] && _ver_ge "$current" "$min_version"; then
     ok "podman compose delegates to Docker Compose ${current} (>= ${min_version})"
     return 0

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-# Setup, dependency installation, and prerequisite checks.
-# Expects: DEVTOOLS_DIR, COMPOSE, REPOS_CONF (exported by Justfile)
-# Source scripts/common.sh and scripts/repos.sh before this file.
+# Expects DEVTOOLS_DIR, COMPOSE, REPOS_CONF (exported by Justfile); source common.sh + repos.sh first.
 
 detect_distro() {
   if command -v pacman &>/dev/null; then
@@ -12,6 +10,35 @@ detect_distro() {
     echo "fedora"
   else
     echo "unknown"
+  fi
+}
+
+_version_ge() {
+  local IFS=.
+  local -a A=($1) B=($2)
+  local i av bv
+  for i in 0 1 2; do
+    av="${A[i]:-0}"; bv="${B[i]:-0}"
+    (( av > bv )) && return 0
+    (( av < bv )) && return 1
+  done
+  return 0
+}
+
+_check_just_min_version() {
+  local need="$1"
+  local current
+  if ! current="$(just --version 2>/dev/null | awk '{print $2}')" || [ -z "$current" ]; then
+    err "Could not read 'just --version'. Did 'just' move off PATH?"
+    exit 1
+  fi
+  if ! _version_ge "$current" "$need"; then
+    err "Found just $current, need >= $need."
+    err "Likely cause: 'apt install just' (Ubuntu LTS ships 1.21, frozen)."
+    err "Fix:"
+    err "  bash $DEVTOOLS_DIR/scripts/bootstrap.sh"
+    err "  # then open a new shell and re-run 'just setup::init'"
+    exit 1
   fi
 }
 
@@ -28,20 +55,20 @@ pkg_name() {
   local generic="$1"
   local distro
   distro="$(detect_distro)"
+  # No debian:container-compose entry -- Debian's apt compose is too old; see install_compose_upstream.
   case "${distro}:${generic}" in
-    arch:docker)           echo "docker" ;;
-    arch:docker-compose)   echo "docker-compose" ;;
-    arch:git)              echo "git" ;;
-    arch:distrobox)        echo "distrobox" ;;
-    debian:docker)         echo "docker.io" ;;
-    debian:docker-compose) echo "docker-compose-plugin" ;;
-    debian:git)            echo "git" ;;
-    debian:distrobox)      echo "distrobox" ;;
-    fedora:docker)         echo "docker-ce docker-ce-cli containerd.io" ;;
-    fedora:docker-compose) echo "docker-compose-plugin" ;;
-    fedora:git)            echo "git" ;;
-    fedora:distrobox)      echo "distrobox" ;;
-    *)                     echo "$generic" ;;
+    arch:container-runtime)    echo "podman" ;;
+    arch:container-compose)    echo "docker-compose" ;;
+    arch:git)                  echo "git" ;;
+    arch:distrobox)            echo "distrobox" ;;
+    debian:container-runtime)  echo "podman" ;;
+    debian:git)                echo "git" ;;
+    debian:distrobox)          echo "distrobox" ;;
+    fedora:container-runtime)  echo "podman" ;;
+    fedora:container-compose)  echo "docker-compose" ;;
+    fedora:git)                echo "git" ;;
+    fedora:distrobox)          echo "distrobox" ;;
+    *)                         echo "$generic" ;;
   esac
 }
 
@@ -53,25 +80,29 @@ check_git() {
   ok "git $(git --version | awk '{print $3}') detected"
 }
 
-check_docker() {
-  if ! command -v docker &>/dev/null; then
-    err "Docker is not installed."
+check_podman() {
+  if ! command -v podman &>/dev/null; then
+    err "podman is not installed."
     return 1
   fi
-  if ! docker info &>/dev/null; then
-    err "Docker daemon is not running or current user lacks permissions."
-    echo ""
-    echo "  Start the daemon:   sudo systemctl start docker"
-    echo "  Enable on boot:     sudo systemctl enable docker"
-    echo "  Add yourself:       sudo usermod -aG docker \$USER  (then re-login)"
-    echo ""
+  if ! podman info &>/dev/null; then
+    err "podman is installed but 'podman info' failed (storage init issue?)."
+    info "  Try a fresh init:  podman system reset  (destroys local images)"
     return 1
   fi
-  if ! docker compose version &>/dev/null; then
-    err "Docker Compose V2 plugin is not installed."
+  # podman compose delegates to the buggy python podman-compose unless the Go binary is present.
+  if ! command -v docker-compose &>/dev/null; then
+    err "docker-compose not installed (podman compose dispatcher needs it as provider)."
+    info "  Run: just setup::deps"
     return 1
   fi
-  ok "Docker $(docker --version | awk '{print $3}' | tr -d ',') + Compose V2 detected"
+  local sock="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock"
+  if [ ! -S "$sock" ]; then
+    err "podman socket not active at $sock (docker-compose can't reach the daemon)."
+    info "  Run: just setup::deps"
+    return 1
+  fi
+  ok "podman $(podman --version | awk '{print $3}') + docker-compose $(docker-compose version --short 2>/dev/null) + socket detected"
 }
 
 check_distrobox() {
@@ -105,7 +136,7 @@ check_prerequisites() {
   echo ""
   local failed=0
   check_git       || failed=1
-  check_docker    || failed=1
+  check_podman    || failed=1
   check_distrobox || true
   check_ports
   echo ""
@@ -124,7 +155,198 @@ install_dockerignore() {
   fi
 }
 
+# WSL2: enable systemd, mark / as a shared mount (needed for podman distrobox). No-op elsewhere.
+ensure_wsl_setup() {
+  grep -qi microsoft /proc/version 2>/dev/null || return 0
+
+  echo -e "${BOLD}=== WSL2 environment prep ===${NC}"
+  echo ""
+
+  local wsl_conf="/etc/wsl.conf"
+  local needs_shutdown=0
+
+  [ -f "$wsl_conf" ] || sudo touch "$wsl_conf"
+
+  if ! sudo grep -qE '^\[boot\]' "$wsl_conf"; then
+    info "Adding [boot] section to $wsl_conf"
+    echo -e "\n[boot]" | sudo tee -a "$wsl_conf" >/dev/null
+  fi
+
+  if ! sudo grep -qE '^\s*systemd\s*=\s*true' "$wsl_conf"; then
+    if sudo grep -qE '^\s*systemd\s*=' "$wsl_conf"; then
+      warn "$wsl_conf has 'systemd=' set to a non-true value -- leaving it alone."
+      warn "  BAR-Devtools' container path needs systemd; flip it manually if that's a mistake."
+    else
+      info "Enabling systemd in $wsl_conf"
+      sudo sed -i '/^\[boot\]/a systemd=true' "$wsl_conf"
+      needs_shutdown=1
+    fi
+  fi
+
+  if ! sudo grep -qE '^\s*command\s*=.*make-rshared' "$wsl_conf"; then
+    info "Persisting 'mount --make-rshared /' in $wsl_conf (rebind / as shared mount on every boot)"
+    sudo sed -i '/^\[boot\]/a command="mount --make-rshared /"' "$wsl_conf"
+  fi
+
+  if [ "$(ps -p 1 -o comm= 2>/dev/null)" != "systemd" ] || [ "$needs_shutdown" -eq 1 ]; then
+    echo ""
+    warn "WSL must restart to pick up systemd."
+    warn "  From Windows PowerShell:  wsl --shutdown"
+    warn "  Then reopen WSL and re-run: just setup::init"
+    exit 0
+  fi
+
+  local rootprop
+  rootprop="$(findmnt -no PROPAGATION / 2>/dev/null || echo unknown)"
+  if [ "$rootprop" != "shared" ]; then
+    info "Re-mounting / as shared (one-shot for current boot; persisted via wsl.conf above)"
+    sudo mount --make-rshared /
+    rootprop="$(findmnt -no PROPAGATION /)"
+    if [ "$rootprop" != "shared" ]; then
+      err "Failed to mark / as shared (got '$rootprop'). Cannot proceed."
+      exit 1
+    fi
+  fi
+
+  ok "WSL2 environment ready (systemd active, / is a shared mount)"
+  echo ""
+}
+
+# True if $1 is a real Windows Python, not the Microsoft Store stub under WindowsApps.
+_is_real_windows_python() {
+  local p="$1"
+  [ -n "$p" ] || return 1
+  case "$p" in
+    *WindowsApps*python.exe|*WindowsApps*py.exe) return 1 ;;
+  esac
+  return 0
+}
+
+# Install Python on the Windows host via winget. WSL-only; skips if a real Windows Python exists.
+ensure_windows_python() {
+  is_wsl || return 0
+
+  local py_path python_path
+  py_path="$(command -v py.exe 2>/dev/null || true)"
+  python_path="$(command -v python.exe 2>/dev/null || true)"
+
+  if _is_real_windows_python "$py_path"; then
+    ok "Windows Python already installed: $py_path"
+    ensure_bar_launch_python_persisted
+    return 0
+  fi
+  if _is_real_windows_python "$python_path"; then
+    ok "Windows Python already installed: $python_path"
+    ensure_bar_launch_python_persisted
+    return 0
+  fi
+
+  if [ -n "$python_path" ]; then
+    info "Detected Microsoft Store python.exe stub at $python_path -- not a real install."
+  fi
+
+  if ! command -v winget.exe &>/dev/null; then
+    warn "winget.exe not found on the Windows PATH -- can't auto-install Python."
+    warn "Install manually from https://www.python.org/downloads/ and re-open the WSL shell."
+    return 0
+  fi
+
+  echo ""
+  info "The Windows-side cold-copy mirror needs py.exe / python.exe on Windows."
+  read -rp "Install Python 3.12 via winget on Windows now? [Y/n] " ans
+  if [[ "$ans" =~ ^[Nn]$ ]]; then
+    info "Skipped. Run later: winget install Python.Python.3.12"
+    return 0
+  fi
+
+  step "Installing Python 3.12 on Windows via winget..."
+  winget.exe install Python.Python.3.12 \
+    --silent \
+    --accept-source-agreements \
+    --accept-package-agreements \
+    || warn "winget exited non-zero. Check the output above; Python may still be installed."
+
+  hash -r
+  py_path="$(command -v py.exe 2>/dev/null || true)"
+  python_path="$(command -v python.exe 2>/dev/null || true)"
+  if _is_real_windows_python "$py_path" || _is_real_windows_python "$python_path"; then
+    ok "Windows Python installed."
+    ensure_bar_launch_python_persisted
+  else
+    warn "winget finished but a real py.exe / python.exe still isn't on PATH."
+    warn "Open a new WSL shell (Windows PATH is re-imported at WSL shell start)."
+    warn "If it still isn't visible, check: winget list Python.Python.3.12 (from cmd/PowerShell)."
+  fi
+}
+
+# Install distrobox from upstream; need >= 1.8.2.3 for the chpasswd fix against shadow-utils 4.13+.
+install_distrobox_upstream() {
+  local current
+  current="$(/usr/local/bin/distrobox --version 2>/dev/null | awk '{print $NF}')"
+  if [ -n "$current" ] && _ver_ge "$current" "1.8.2.3"; then
+    ok "distrobox already up-to-date at /usr/local/bin: $current"
+    return 0
+  fi
+  info "Installing distrobox from upstream (need >= 1.8.2.3 for the chpasswd-hash-validation fix)..."
+  sudo apt-get purge -y distrobox 2>/dev/null || true
+  curl -fsSL https://raw.githubusercontent.com/89luca89/distrobox/main/install \
+    | sudo sh -s -- --prefix /usr/local
+  hash -r
+  ok "distrobox installed: $(/usr/local/bin/distrobox --version 2>/dev/null | awk '{print $NF}')"
+}
+
+_ver_ge() {
+  local IFS=.
+  local -a a=($1) b=($2)
+  local i max=${#a[@]}
+  [ "${#b[@]}" -gt "$max" ] && max=${#b[@]}
+  for ((i=0; i<max; i++)); do
+    local ai=${a[i]:-0} bi=${b[i]:-0}
+    if (( 10#$ai > 10#$bi )); then return 0; fi
+    if (( 10#$ai < 10#$bi )); then return 1; fi
+  done
+  return 0
+}
+
+# Docker Compose v5+ from upstream releases. Compose v2.x defaults to bake/BuildKit, which podman
+# can't drive; v5 degrades gracefully. Skips if v5+ is already on PATH.
+install_compose_upstream() {
+  local min_version="5.0.0"
+  local pin_version="5.1.3"
+  local current=""
+  if command -v docker-compose &>/dev/null; then
+    current="$(docker-compose version --short 2>/dev/null | sed 's/^v//')"
+  fi
+  if [ -n "$current" ] && _ver_ge "$current" "$min_version"; then
+    ok "docker-compose ${current} already installed (>= ${min_version})"
+    return 0
+  fi
+
+  local arch
+  case "$(uname -m)" in
+    x86_64)  arch="x86_64" ;;
+    aarch64) arch="aarch64" ;;
+    *) err "install_compose_upstream: unsupported arch $(uname -m)"; return 1 ;;
+  esac
+
+  local plugin_dir="/usr/local/lib/docker/cli-plugins"
+  local target="${plugin_dir}/docker-compose"
+  local symlink="/usr/local/bin/docker-compose"
+  local url="https://github.com/docker/compose/releases/download/v${pin_version}/docker-compose-linux-${arch}"
+
+  info "Installing docker-compose v${pin_version} from upstream releases (apt's is ${current:-missing})..."
+  sudo mkdir -p "$plugin_dir"
+  sudo curl -fsSL "$url" -o "$target"
+  sudo chmod +x "$target"
+  sudo ln -sf "$target" "$symlink"
+  hash -r
+  ok "docker-compose installed: $(docker-compose version --short 2>/dev/null)"
+}
+
 cmd_install_deps() {
+  # Host-only: package post-install scriptlets need a real systemd, absent in rootless containers.
+  require_host
+
   echo -e "${BOLD}=== Install System Dependencies ===${NC}"
   echo ""
 
@@ -133,6 +355,11 @@ cmd_install_deps() {
   local install_cmd
   install_cmd="$(pkg_install_cmd)"
 
+  if [ "$distro" = "unknown" ] || [ -z "$install_cmd" ]; then
+    err "Unsupported distro. Install these manually: git, podman, docker-compose >= 5.0, distrobox"
+    info "See docker/dev.Containerfile for the full list of dev tool dependencies."
+    exit 1
+  fi
 
   info "Detected distro: ${BOLD}${distro}${NC}"
   echo ""
@@ -142,74 +369,739 @@ cmd_install_deps() {
   if ! command -v git &>/dev/null; then
     missing+=("git")
   fi
-  if ! command -v docker &>/dev/null; then
-    missing+=("docker")
+  if ! command -v podman &>/dev/null; then
+    missing+=("container-runtime")
   fi
-  if ! docker compose version &>/dev/null 2>&1; then
-    missing+=("docker-compose")
+  # Debian gets compose from install_compose_upstream below, never from apt.
+  if [ "$distro" != "debian" ] && ! command -v docker-compose &>/dev/null; then
+    missing+=("container-compose")
   fi
   if ! command -v distrobox &>/dev/null; then
     missing+=("distrobox")
   fi
 
-  if [ "${#missing[@]}" -eq 0 ]; then
-    ok "All dependencies already installed."
-    echo ""
-
-    if ! docker info &>/dev/null; then
-      warn "Docker is installed but the daemon isn't running or you lack permissions."
-      echo ""
-      echo "  sudo systemctl start docker"
-      echo "  sudo systemctl enable docker"
-      echo "  sudo usermod -aG docker \$USER   # then re-login"
-      echo ""
-    fi
-    return 0
-  elif [ "$distro" = "unknown" ] || [ -z "$install_cmd" ]; then
-    err "Unsupported distro. Install these manually: git, docker, docker-compose, distrobox"
-    info "See docker/dev.Containerfile for the full list of dev tool dependencies."
-    exit 1
-  fi
-
-  local packages=""
-  for dep in "${missing[@]}"; do
-    packages+=" $(pkg_name "$dep")"
+  # Debian gets distrobox from upstream; drop it from the apt list.
+  local apt_missing=()
+  for tool in "${missing[@]}"; do
+    if [ "$distro" = "debian" ] && [ "$tool" = "distrobox" ]; then continue; fi
+    apt_missing+=("$tool")
   done
 
-  info "Missing: ${missing[*]}"
-  info "Will run: ${install_cmd}${packages}"
-  echo ""
+  if [ "${#apt_missing[@]}" -gt 0 ]; then
+    local packages=""
+    for dep in "${apt_missing[@]}"; do
+      packages+=" $(pkg_name "$dep")"
+    done
 
-  read -rp "Install now? [Y/n] " confirm
-  if [[ "$confirm" =~ ^[Nn]$ ]]; then
-    echo "Skipped. Install manually and retry."
-    return 1
+    info "Missing (via package manager): ${apt_missing[*]}"
+    info "Running: ${install_cmd}${packages}"
+    echo ""
+    $install_cmd $packages
+    echo ""
   fi
 
-  $install_cmd $packages
-
+  if [ "$distro" = "debian" ]; then
+    install_distrobox_upstream
+    echo ""
+  fi
+  install_compose_upstream
   echo ""
 
-  if [[ " ${missing[*]} " == *" docker "* ]]; then
-    info "Enabling and starting Docker daemon..."
-    sudo systemctl enable --now docker 2>/dev/null || true
-
-    if ! groups | grep -qw docker; then
-      info "Adding $USER to the docker group (re-login required)..."
-      sudo usermod -aG docker "$USER"
-      warn "You need to log out and back in for Docker group membership to take effect."
-      warn "After re-login, run: just setup::init"
-      return 0
-    fi
-  fi
+  ensure_podman_socket
+  echo ""
 
   ok "Dependencies installed successfully."
 }
 
+# Enable podman.socket + loginctl linger so the user systemd socket survives logout (WSL2 needs this).
+ensure_podman_socket() {
+  if ! systemctl --user is-enabled podman.socket &>/dev/null; then
+    info "Enabling user systemd podman.socket..."
+    systemctl --user enable podman.socket
+  fi
+  if ! systemctl --user is-active podman.socket &>/dev/null; then
+    info "Starting user systemd podman.socket..."
+    systemctl --user start podman.socket
+  fi
+
+  if ! loginctl show-user "$USER" 2>/dev/null | grep -q '^Linger=yes'; then
+    info "Enabling loginctl linger for ${USER} (so podman.socket survives logout)..."
+    sudo loginctl enable-linger "$USER"
+  fi
+
+  local sock="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock"
+  if [ -S "$sock" ]; then
+    ok "podman socket active at $sock"
+  else
+    err "podman.socket says active but $sock isn't there. Try: systemctl --user restart podman.socket"
+    return 1
+  fi
+}
+
+# Resolve the bar_debug_launcher checkout, honoring a repos.local.conf override.
+bar_launch_repo_path() {
+  load_repos_conf
+  local i
+  for i in "${!REPO_DIRS[@]}"; do
+    if [ "${REPO_DIRS[$i]}" = "bar_debug_launcher" ]; then
+      local local_path="${REPO_LOCAL_PATHS[$i]}"
+      if [ -n "$local_path" ] && [ -d "$local_path" ]; then
+        echo "$local_path"
+        return 0
+      fi
+      break
+    fi
+  done
+  echo "$DEVTOOLS_DIR/bar_debug_launcher"
+}
+
+# True on rpm-ostree systems, where the package layer is read-only at runtime.
+_is_ostree() {
+  command -v rpm-ostree &>/dev/null && [ -e /run/ostree-booted ]
+}
+
+# Install pipx if missing. On rpm-ostree, bootstrap it via `pip install --user`.
+_ensure_pipx() {
+  if command -v pipx &>/dev/null; then return 0; fi
+
+  if _is_ostree; then
+    info "rpm-ostree system detected -- bootstrapping pipx via 'pip install --user'"
+    if ! command -v python3 &>/dev/null; then
+      err "python3 not found on PATH"
+      return 1
+    fi
+    # --break-system-packages: PEP 668 EXTERNALLY-MANAGED; only touches ~/.local site-packages.
+    python3 -m pip install --user --break-system-packages --quiet pipx \
+      || { err "pip install --user pipx failed"; return 1; }
+    python3 -m pipx ensurepath >/dev/null 2>&1 || true
+    export PATH="$HOME/.local/bin:$PATH"
+    hash -r
+    command -v pipx &>/dev/null && return 0
+    err "pipx installed to ~/.local/bin but still not on PATH"
+    info "Open a new shell, or add ~/.local/bin to PATH"
+    return 1
+  fi
+
+  local distro install_cmd
+  distro="$(detect_distro)"
+  case "$distro" in
+    arch)   install_cmd="sudo pacman -S --needed python-pipx" ;;
+    debian) install_cmd="sudo apt install -y pipx" ;;
+    fedora) install_cmd="sudo dnf install -y pipx" ;;
+    *)      install_cmd="" ;;
+  esac
+
+  if [ -z "$install_cmd" ]; then
+    err "pipx is not installed and your distro is unknown. Install pipx manually:"
+    info "  https://pipx.pypa.io/stable/installation/"
+    return 1
+  fi
+
+  info "pipx not found. Installing: $install_cmd"
+  $install_cmd || { err "pipx install failed"; return 1; }
+  pipx ensurepath >/dev/null 2>&1 || true
+  hash -r
+  command -v pipx &>/dev/null
+}
+
+# Find a Python >= 3.10 that can `import tkinter`. Probes /usr/bin paths so a pyenv shim can't shadow it.
+_pick_tkinter_python() {
+  local cand
+  for cand in \
+      /usr/bin/python3.13 /usr/bin/python3.12 /usr/bin/python3.11 /usr/bin/python3.10 /usr/bin/python3 \
+      python3.13 python3.12 python3.11 python3.10 python3; do
+    local resolved
+    resolved="$(command -v "$cand" 2>/dev/null)" || continue
+    "$resolved" - <<'PY' 2>/dev/null && { echo "$resolved"; return 0; }
+import sys
+if sys.version_info < (3, 10):
+    sys.exit(1)
+import tkinter  # noqa: F401  -- imports _tkinter as a side effect
+PY
+  done
+  return 1
+}
+
+# Editable-install the launcher with pipx, exposing the `bar-launch` entry point on PATH.
+ensure_bar_launch_installed() {
+  local repo_path="$1"
+  if [ ! -f "$repo_path/pyproject.toml" ]; then
+    err "bar_debug_launcher pyproject.toml missing at $repo_path"
+    return 1
+  fi
+
+  _ensure_pipx || return 1
+
+  local target_py
+  target_py="$(_pick_tkinter_python || true)"
+  if [ -z "$target_py" ]; then
+    err "No Python ≥ 3.10 with a working tkinter found."
+    info "The launcher's GUI imports tkinter; pipx will not auto-fix this."
+    info "Fedora:  sudo dnf install python3-tkinter   (or rpm-ostree install)"
+    info "Debian:  sudo apt install python3-tk"
+    info "Arch:    sudo pacman -S tk"
+    info "pyenv:   install tk-devel (Fedora) / tk-dev (Debian) and rebuild Python"
+    return 1
+  fi
+
+  step "Installing bar_debug_launcher via pipx (editable, --python $target_py)"
+  # Uninstall first: `pipx install --force` ignores --python when reusing an existing venv.
+  pipx uninstall bar-launch >/dev/null 2>&1 || true
+  pipx uninstall bar_launch >/dev/null 2>&1 || true
+  pipx install --editable --python "$target_py" "$repo_path"
+
+  # Marker lets launch.sh detect pyproject.toml manifest changes and trigger a reinstall.
+  mkdir -p "${XDG_STATE_HOME:-$HOME/.local/state}/bar-devtools"
+  touch "${XDG_STATE_HOME:-$HOME/.local/state}/bar-devtools/bar-launch-installed"
+
+  ok "bar-launch installed (entry point: $(command -v bar-launch || echo "~/.local/bin/bar-launch"))"
+
+  if ! command -v bar-launch &>/dev/null; then
+    warn "bar-launch isn't on PATH yet. Open a new shell, or run: pipx ensurepath"
+  fi
+}
+
+cmd_setup_bar_launch() {
+  local repo_path
+  repo_path="$(bar_launch_repo_path)"
+  if [ ! -d "$repo_path/bar_launch" ]; then
+    info "bar_debug_launcher not checked out at $repo_path -- skipping bar-launch install."
+    info "Add it via: just repos::clone bar (or set local_path in repos.local.conf)."
+    return 0
+  fi
+  ensure_bar_launch_installed "$repo_path"
+  ensure_bar_appimage_path_set
+}
+
+# Echo a Beyond-All-Reason*.AppImage found in $1 (case-insensitive), or nothing.
+_find_appimage_in_dir() {
+  local dir="$1"
+  [ -d "$dir" ] || return 0
+  local f
+  while IFS= read -r f; do
+    echo "$f"
+    return 0
+  done < <(find "$dir" -maxdepth 1 -type f \( \
+              -iname 'beyond-all-reason*.appimage' -o \
+              -iname 'beyond_all_reason*.appimage' -o \
+              -iname 'beyondallreason*.appimage' \) 2>/dev/null | sort -r)
+}
+
+# Resolve BAR_APPIMAGE_PATH: keep existing, else auto-discover ~/Applications, else prompt.
+ensure_bar_appimage_path_set() {
+  local env_file="$DEVTOOLS_DIR/.env"
+  touch "$env_file"
+
+  if grep -q "^BAR_APPIMAGE_PATH=" "$env_file" 2>/dev/null; then
+    info "BAR_APPIMAGE_PATH already set in .env"
+    return 0
+  fi
+
+  local found
+  found="$(_find_appimage_in_dir "$HOME/Applications")"
+  if [ -n "$found" ]; then
+    echo "BAR_APPIMAGE_PATH=$found" >> "$env_file"
+    ok "Discovered AppImage at $found (added to .env)"
+    return 0
+  fi
+
+  if ! [ -t 0 ]; then
+    warn "Beyond-All-Reason AppImage not found in ~/Applications and no TTY for prompting."
+    info "If you want '--boot launcher' to work, add to BAR-Devtools/.env:"
+    info "  BAR_APPIMAGE_PATH=/path/to/Beyond-All-Reason.AppImage  (or a directory containing one)"
+    info "Engine-direct boots (--boot engine) work without this."
+    return 0
+  fi
+
+  echo ""
+  warn "Beyond-All-Reason AppImage not found in ~/Applications."
+  info "bar-launch needs this only when booting via the AppImage launcher"
+  info "(--boot launcher / chobby default). Engine-direct boots don't."
+  echo ""
+  echo "  Common locations:"
+  echo "    ~/Applications/Beyond-All-Reason.AppImage   (AppImageLauncher canonical)"
+  echo "    ~/apps/<anywhere>/                          (directory containing the AppImage)"
+  echo "    /opt/BAR/Beyond-All-Reason.AppImage"
+  echo ""
+  local response
+  read -rp "Path to AppImage (or directory containing it; blank to skip): " response
+  if [ -z "$response" ]; then
+    warn "Skipped. '--boot launcher' will fail until BAR_APPIMAGE_PATH is set in .env."
+    return 0
+  fi
+
+  local expanded="${response/#\~/$HOME}"
+  if [ -f "$expanded" ]; then
+    echo "BAR_APPIMAGE_PATH=$expanded" >> "$env_file"
+    ok "Added BAR_APPIMAGE_PATH=$expanded to .env"
+  elif [ -d "$expanded" ]; then
+    local resolved
+    resolved="$(_find_appimage_in_dir "$expanded")"
+    if [ -n "$resolved" ]; then
+      # Persist the directory, not the file, so in-place AppImage upgrades don't need a .env edit.
+      echo "BAR_APPIMAGE_PATH=$expanded" >> "$env_file"
+      ok "Added BAR_APPIMAGE_PATH=$expanded to .env (resolves to $resolved)"
+    else
+      warn "$expanded is a directory but contains no Beyond-All-Reason*.AppImage."
+      warn "Saving anyway -- the launcher will scan it again at run time."
+      echo "BAR_APPIMAGE_PATH=$expanded" >> "$env_file"
+    fi
+  else
+    err "$expanded does not exist."
+    info "Edit BAR-Devtools/.env directly when you have the path:"
+    info "  BAR_APPIMAGE_PATH=/path/to/Beyond-All-Reason.AppImage"
+    return 1
+  fi
+}
+
+# BAR_DATA_DIR: the engine's data dir. WSL2 mirrors sources into it; Linux symlinks into it.
+
+bar_data_dir_get() {
+  local env_file="$DEVTOOLS_DIR/.env"
+  if [ -f "$env_file" ]; then
+    local val
+    val="$(grep -E '^BAR_DATA_DIR=' "$env_file" 2>/dev/null | tail -n1 | cut -d= -f2-)"
+    if [ -n "$val" ]; then
+      val="${val%\"}"; val="${val#\"}"
+      echo "$val"
+      return 0
+    fi
+  fi
+  echo "${BAR_DATA_DIR:-}"
+}
+
+_to_windows_path() {
+  local p="$1"
+  if command -v wslpath &>/dev/null; then
+    wslpath -w "$p" 2>/dev/null || echo "$p"
+  else
+    echo "$p"
+  fi
+}
+
+_to_wsl_path() {
+  local p="$1"
+  if command -v wslpath &>/dev/null; then
+    wslpath -u "$p" 2>/dev/null || echo "$p"
+  else
+    echo "$p"
+  fi
+}
+
+# Default to the BAR launcher's own data dir: spring's archive scanner won't traverse junctions.
+_default_bar_data_dir() {
+  is_wsl || return 0
+  command -v cmd.exe &>/dev/null || return 0
+  command -v wslpath &>/dev/null || return 0
+  local localappdata
+  localappdata="$(cmd.exe /c 'echo %LOCALAPPDATA%' 2>/dev/null | tr -d '\r\n')"
+  [ -z "$localappdata" ] && return 0
+  case "$localappdata" in
+    *%LOCALAPPDATA%*) return 0 ;;
+  esac
+  local wsl_path
+  wsl_path="$(wslpath -u "$localappdata" 2>/dev/null)" || return 0
+  local launcher_data="$wsl_path/Programs/Beyond-All-Reason/data"
+  if [ -d "$launcher_data" ]; then
+    echo "$launcher_data"
+  else
+    echo "$wsl_path/BAR-DevSync"
+  fi
+}
+
+# Idempotently set `<key> = <value>` in a springsettings.cfg. The engine rewrites the cfg on
+# shutdown, so callers should re-apply on every launch.
+springsettings_set() {
+  local cfg="${1:-}" key="${2:-}" value="${3:-}"
+  if [ -z "$cfg" ] || [ -z "$key" ]; then
+    return 1
+  fi
+  if [ ! -f "$cfg" ]; then
+    : > "$cfg" 2>/dev/null || { warn "Couldn't create $cfg"; return 1; }
+  fi
+  if grep -qE "^[[:space:]]*${key}[[:space:]]*=" "$cfg" 2>/dev/null; then
+    local tmp="$cfg.tmp.$$"
+    # # as sed delimiter so values with / don't bite us.
+    sed -E "s#^[[:space:]]*${key}[[:space:]]*=.*\$#${key} = ${value}#" \
+      "$cfg" > "$tmp" 2>/dev/null \
+      && mv "$tmp" "$cfg" \
+      || { rm -f "$tmp"; warn "Couldn't update $key in $cfg"; return 1; }
+  else
+    printf '%s = %s\n' "$key" "$value" >> "$cfg" \
+      || { warn "Couldn't append $key to $cfg"; return 1; }
+  fi
+}
+
+# Drop an empty devmode.txt at the engine's data dir to enable Recoil's developer mode.
+ensure_devmode_marker() {
+  local data_dir="${1:-}"
+  [ -n "$data_dir" ] || return 0
+  [ -d "$data_dir" ] || return 0
+  local marker="$data_dir/devmode.txt"
+  [ -e "$marker" ] && return 0
+  # {} around the redirect so 2>/dev/null also catches a redirect-setup failure.
+  if { : > "$marker"; } 2>/dev/null; then
+    info "Created $marker (Recoil dev mode marker)"
+  else
+    warn "Couldn't create $marker (continuing without dev mode)"
+  fi
+}
+
+# Persist BAR_DATA_DIR in WSL path form; the Windows shim converts it. WSL-only.
+ensure_bar_data_dir() {
+  is_wsl || return 0
+
+  local env_file="$DEVTOOLS_DIR/.env"
+  touch "$env_file"
+
+  local current
+  current="$(bar_data_dir_get)"
+  if [ -n "$current" ]; then
+    info "BAR_DATA_DIR already set: $current"
+  else
+    echo ""
+    info "WSL2 detected. Linux↔Windows symlinks aren't fast enough for runtime"
+    info "game-Lua reads, so BAR-Devtools mirrors your Devtools checkouts to a"
+    info "Windows-side data directory the engine reads from. The recommended"
+    info "target is the BAR launcher's own data dir -- spring then sees our"
+    info "synced bar/chobby/engine alongside its own cache/demos/settings"
+    info "without any junctions in the path."
+    echo ""
+    echo "  Recommended:  %LOCALAPPDATA%\\Programs\\Beyond-All-Reason\\data\\"
+    echo "                (the data dir Beyond-All-Reason.exe already writes to)"
+    echo "  Avoid:        %USERPROFILE%\\Documents\\... (OneDrive redirection)"
+    echo "                %TEMP%\\...                  (cleared on reboot)"
+    echo "                \\\\wsl\$\\<distro>\\...        (defeats the whole point)"
+    echo ""
+    local default_path
+    default_path="$(_default_bar_data_dir)"
+
+    local response
+    if [ -t 0 ]; then
+      if [ -n "$default_path" ]; then
+        read -rp "BAR data dir [$(_to_windows_path "$default_path")]: " response
+      else
+        read -rp "BAR data dir (WSL path or Windows path): " response
+      fi
+    else
+      response=""
+    fi
+
+    if [ -z "$response" ]; then
+      if [ -z "$default_path" ]; then
+        err "No BAR_DATA_DIR provided and couldn't compute a default (cmd.exe / wslpath unavailable)."
+        info "Edit BAR-Devtools/.env directly:  BAR_DATA_DIR=/mnt/c/Users/<you>/AppData/Local/BAR-DevSync"
+        return 1
+      fi
+      current="$default_path"
+    else
+      case "$response" in
+        /mnt/*|/home/*|/root/*) current="${response/#\~/$HOME}" ;;
+        *)
+          local converted
+          converted="$(_to_wsl_path "$response")"
+          if [ -z "$converted" ] || [ "$converted" = "$response" ]; then
+            warn "Couldn't convert '$response' via wslpath -- saving as-is."
+            current="$response"
+          else
+            current="$converted"
+          fi
+          ;;
+      esac
+    fi
+
+    echo "BAR_DATA_DIR=$current" >> "$env_file"
+    ok "Added BAR_DATA_DIR=$current to .env"
+  fi
+
+  local sub
+  for sub in engine/local-build games/Beyond-All-Reason.sdd games/BYAR-Chobby.sdd bin; do
+    mkdir -p "$current/$sub" 2>/dev/null || {
+      err "Couldn't mkdir $current/$sub -- check that the path is reachable from WSL."
+      return 1
+    }
+  done
+
+  ensure_devmode_marker "$current"
+
+  ok "BAR data dir ready: $current"
+
+  export BAR_DATA_DIR="$current"
+}
+
+# Persist BAR_LAUNCH_PYTHON=<py.exe path> to .env. WSL-only.
+ensure_bar_launch_python_persisted() {
+  is_wsl || return 0
+  local env_file="$DEVTOOLS_DIR/.env"
+  touch "$env_file"
+
+  if grep -q "^BAR_LAUNCH_PYTHON=" "$env_file" 2>/dev/null; then
+    return 0
+  fi
+
+  local py_path
+  py_path="$(command -v py.exe 2>/dev/null || true)"
+  if ! _is_real_windows_python "$py_path"; then
+    py_path="$(command -v python.exe 2>/dev/null || true)"
+  fi
+  if ! _is_real_windows_python "$py_path"; then
+    return 0
+  fi
+
+  local win_py
+  win_py="$(_to_windows_path "$py_path")"
+  # Single-quote: just's dotenv parser would treat backslashes in C:\... as escapes.
+  echo "BAR_LAUNCH_PYTHON='$win_py'" >> "$env_file"
+  ok "Added BAR_LAUNCH_PYTHON=$win_py to .env"
+}
+
+# Build a Windows venv (not WSL): the launcher spawns the native Windows engine, avoiding a WSL hop.
+ensure_bar_launch_venv_windows() {
+  is_wsl || return 0
+
+  local data_dir_wsl="${BAR_DATA_DIR:-$(bar_data_dir_get)}"
+  if [ -z "$data_dir_wsl" ]; then
+    warn "BAR_DATA_DIR not set -- skipping Windows venv bootstrap."
+    return 0
+  fi
+
+  local py_path
+  py_path="$(command -v py.exe 2>/dev/null || true)"
+  if ! _is_real_windows_python "$py_path"; then
+    py_path="$(command -v python.exe 2>/dev/null || true)"
+  fi
+  if ! _is_real_windows_python "$py_path"; then
+    warn "No real Windows Python found -- skipping venv bootstrap."
+    info "Run 'just setup::init' again after installing Python on Windows."
+    return 0
+  fi
+
+  local venv_wsl="$data_dir_wsl/.venv"
+  local venv_python_wsl="$venv_wsl/Scripts/python.exe"
+
+  if [ ! -x "$venv_python_wsl" ] && [ ! -f "$venv_python_wsl" ]; then
+    step "Creating Windows venv at $venv_wsl"
+    "$py_path" -3 -m venv "$(_to_windows_path "$venv_wsl")" \
+      || { err "Failed to create venv at $venv_wsl"; return 1; }
+  fi
+
+  if [ ! -f "$venv_python_wsl" ]; then
+    err "venv created but $venv_python_wsl is missing -- aborting."
+    return 1
+  fi
+
+  local repo_path
+  repo_path="$(bar_launch_repo_path)"
+  if [ ! -f "$repo_path/pyproject.toml" ]; then
+    err "bar_debug_launcher checkout missing at $repo_path -- skipping venv install."
+    return 1
+  fi
+
+  step "Installing bar_debug_launcher into Windows venv"
+  local repo_unc
+  repo_unc="$(_to_windows_path "$repo_path")"
+  "$venv_python_wsl" -m pip install --upgrade pip --quiet \
+    || warn "pip self-upgrade failed; continuing"
+  "$venv_python_wsl" -m pip install --quiet --editable "$repo_unc" \
+    || { err "pip install bar_debug_launcher failed"; return 1; }
+
+  ok "Windows venv ready: $venv_wsl"
+  export BAR_LAUNCH_VENV="$venv_wsl"
+}
+
+# Generate <BAR_DATA_DIR>/bin/bar-launch.cmd with absolute Windows paths baked in.
+regenerate_bar_launch_cmd_shim() {
+  is_wsl || return 0
+
+  local data_dir_wsl="${BAR_DATA_DIR:-$(bar_data_dir_get)}"
+  if [ -z "$data_dir_wsl" ]; then
+    err "BAR_DATA_DIR not set -- run 'just setup::init' on WSL first."
+    return 1
+  fi
+
+  local venv_python_wsl="$data_dir_wsl/.venv/Scripts/python.exe"
+  if [ ! -f "$venv_python_wsl" ]; then
+    err "Windows venv python not found at $venv_python_wsl"
+    info "Run 'just setup::init' to create it."
+    return 1
+  fi
+
+  local shim_wsl="$data_dir_wsl/bin/bar-launch.cmd"
+  mkdir -p "$(dirname "$shim_wsl")"
+
+  local venv_python_win data_dir_win
+  venv_python_win="$(_to_windows_path "$venv_python_wsl")"
+  data_dir_win="$(_to_windows_path "$data_dir_wsl")"
+
+  cat > "$shim_wsl" <<EOF
+@echo off
+REM Generated by BAR-Devtools setup. Edit via: just bar::regen-shim
+"$venv_python_win" -m bar_launch --data-dir "$data_dir_win" %*
+EOF
+  sed -i 's/$/\r/' "$shim_wsl"
+
+  ok "Generated $shim_wsl"
+}
+
+# Show every decision + the work ahead, then gate on a single Y/n.
+confirm_setup_plan() {
+  local features="$1" game_dir="$2" do_link="$3"
+
+  echo ""
+  echo -e "${BOLD}=== setup::init will now make these changes ===${NC}"
+  echo ""
+
+  echo "  Your choices:"
+  summarize_modules
+  echo ""
+
+  echo "  System (host):"
+  echo "    install any missing packages -- git, podman, distrobox (needs sudo)"
+  # grep -F not -q: under pipefail, -q's early exit SIGPIPEs `distrobox list` and flips the result.
+  local dbx_built=0 dbx_listing
+  if command -v distrobox >/dev/null 2>&1; then
+    dbx_listing="$(distrobox list 2>/dev/null || true)"
+    if printf '%s\n' "$dbx_listing" | grep -F "| $DEVTOOLS_DISTROBOX " >/dev/null 2>&1; then
+      dbx_built=1
+    fi
+  fi
+  if [ "$dbx_built" = 1 ]; then
+    echo "    bar-dev distrobox: already built"
+  else
+    echo "    build the bar-dev distrobox container (~3-5 min, downloads a base image)"
+  fi
+  if is_wsl; then
+    echo "    build the bar-sync distrobox container (WSL filesystem mirror)"
+    echo "    raise fs.inotify.max_user_watches via /etc/sysctl.d (needs sudo)"
+  fi
+  echo ""
+
+  # Bucket selected repos into present vs new (same test as clone_for_features).
+  load_repos_conf
+  local wanted i dir lp r_present=0 r_new=0 new_dirs=()
+  wanted="$(features_to_repos "$features")"
+  for i in "${!REPO_DIRS[@]}"; do
+    dir="${REPO_DIRS[$i]}"
+    [[ " $wanted " == *" $dir "* ]] || continue
+    lp="${REPO_LOCAL_PATHS[$i]}"
+    if { [ -n "$lp" ] && [ -d "$lp" ]; } \
+       || { [ -z "$lp" ] && [ -d "$DEVTOOLS_DIR/$dir/.git" ]; }; then
+      r_present=$((r_present + 1))
+    else
+      r_new=$((r_new + 1))
+      new_dirs+=("$dir")
+    fi
+  done
+  echo "  Repositories (${r_present} present, ${r_new} to clone):"
+  [ "$r_present" -gt 0 ] && echo "    ${r_present} already here -- just fetching updates"
+  if [ "$r_new" -gt 0 ]; then
+    echo "    ${r_new} new -- cloned over the network:"
+    echo "      ${new_dirs[*]}"
+  fi
+  echo ""
+
+  if feature_selected teiserver || feature_selected recoil; then
+    echo "  Build:"
+    if feature_selected teiserver; then
+      echo "    teiserver Docker image (compiles Elixir deps, generates TLS certs)"
+    fi
+    if feature_selected recoil; then
+      echo "    Recoil engine from source (long -- tens of minutes)"
+    fi
+    echo ""
+  fi
+
+  if [ -n "$game_dir" ] && [ "$do_link" = "yes" ]; then
+    echo "  Symlink into ${game_dir}:"
+    if feature_selected recoil; then echo "    engine/local-build"; fi
+    if feature_selected chobby; then echo "    games/BYAR-Chobby.sdd"; fi
+    if feature_selected bar;    then echo "    games/Beyond-All-Reason.sdd"; fi
+    echo ""
+  fi
+
+  echo "  Right after you confirm you'll be asked for your sudo password once"
+  echo "  (package install / sysctl); the rest then runs unattended."
+  echo ""
+  local ans
+  read -rp "  Proceed? [Y/n] " ans
+  if [[ "$ans" =~ ^[Nn] ]]; then
+    info "Cancelled -- nothing has been changed."
+    exit 0
+  fi
+  sudo -v 2>/dev/null || warn "Could not pre-cache sudo; later steps may prompt for your password."
+  echo ""
+}
+
+# Bump fs.inotify.max_user_watches on the host kernel; the BAR tree blows past the default.
+ensure_sync_daemon_deps_wsl() {
+  is_wsl || return 0
+
+  step "Checking WSL sync kernel limits"
+
+  local cur_limit min_limit=131072
+  cur_limit="$(cat /proc/sys/fs/inotify/max_user_watches 2>/dev/null || echo 0)"
+  if [ "$cur_limit" -ge "$min_limit" ]; then
+    info "fs.inotify.max_user_watches=$cur_limit (≥ $min_limit)"
+    ok "WSL sync kernel limits OK"
+    return 0
+  fi
+
+  step "  bumping fs.inotify.max_user_watches → 524288 (sysctl drop-in)"
+  if echo 'fs.inotify.max_user_watches=524288' \
+       | sudo tee /etc/sysctl.d/99-bar-devtools.conf >/dev/null \
+     && sudo sysctl -p /etc/sysctl.d/99-bar-devtools.conf >/dev/null 2>&1; then
+    ok "fs.inotify.max_user_watches set to 524288"
+    return 0
+  fi
+  warn "Could not write /etc/sysctl.d/99-bar-devtools.conf -- watcher may miss events on deep subtrees"
+  return 1
+}
+
+# Container paths of dev binaries exported to the host PATH via distrobox-export.
+DEV_BINARIES=(
+  /usr/local/bin/emmylua_ls
+  /usr/local/bin/emmylua_check
+  /usr/bin/clangd
+  /usr/local/bin/stylua
+  /usr/local/bin/lx
+)
+
+export_dev_binaries() {
+  local local_bin="$HOME/.local/bin" bin export_failures=()
+  mkdir -p "$local_bin"
+  step "Exporting dev binaries from $DEVTOOLS_DISTROBOX → $local_bin"
+  for bin in "${DEV_BINARIES[@]}"; do
+    info "  $(basename "$bin")"
+    if ! distrobox enter "$DEVTOOLS_DISTROBOX" -- distrobox-export --bin "$bin" --export-path "$local_bin" >/dev/null; then
+      export_failures+=("$bin")
+    fi
+  done
+  if [ "${#export_failures[@]}" -gt 0 ]; then
+    err "distrobox-export failed for: ${export_failures[*]}"
+    err "  The bar-dev image may be missing some dnf packages."
+    err "  Recover with: just setup::distrobox"
+    return 1
+  fi
+  case ":$PATH:" in
+    *":$local_bin:"*) ;;
+    *)  warn "$local_bin is not on \$PATH; exported wrappers won't be found by your editor or 'just' recipes."
+        warn "  Add to your shell rc:  export PATH=\"\$HOME/.local/bin:\$PATH\""
+        ;;
+  esac
+  ok "Dev binaries exported"
+}
+
 DEV_IMAGE="bar-dev"
-DEV_BOX="bar-dev"
 
 cmd_setup_distrobox() {
+  require_host
+
+  # --rebuild forces a recreate even when the dev image is unchanged.
+  local force_rebuild=0 arg
+  for arg in "$@"; do
+    if [ "$arg" = "--rebuild" ]; then force_rebuild=1; fi
+  done
+
   echo -e "${BOLD}=== Distrobox Dev Environment ===${NC}"
   echo ""
 
@@ -218,189 +1110,805 @@ cmd_setup_distrobox() {
     exit 1
   fi
 
-  local runtime="podman"
-  command -v podman &>/dev/null || runtime="docker"
+  ensure_wsl_setup
+
+  local env_file="$DEVTOOLS_DIR/.env"
+  touch "$env_file"
+  if ! grep -q "^DEVTOOLS_DISTROBOX=" "$env_file" 2>/dev/null; then
+    echo "DEVTOOLS_DISTROBOX=$DEVTOOLS_DISTROBOX" >> "$env_file"
+    ok "Added DEVTOOLS_DISTROBOX=$DEVTOOLS_DISTROBOX to .env (edit to rename your box)"
+  fi
 
   step "Building dev container image ($DEV_IMAGE)..."
-  $runtime build -t "$DEV_IMAGE" -f "$DEVTOOLS_DIR/docker/dev.Containerfile" "$DEVTOOLS_DIR"
+  podman build -t "$DEV_IMAGE" -f "$DEVTOOLS_DIR/docker/dev.Containerfile" "$DEVTOOLS_DIR"
   ok "Image built: $DEV_IMAGE"
   echo ""
 
-  if distrobox list 2>/dev/null | grep -q "$DEV_BOX"; then
-    warn "Distrobox '$DEV_BOX' already exists. Recreating..."
-    distrobox rm -f "$DEV_BOX"
+  # Recreate the container only when the image id changed; empty id => always recreate.
+  local dev_image_id stamp_file image_changed=0
+  dev_image_id="$(podman image inspect --format '{{.Id}}' "$DEV_IMAGE" 2>/dev/null || true)"
+  stamp_file="$DEVTOOLS_DIR/.devtools/dev-image.id"
+  if [ -z "$dev_image_id" ] || [ ! -f "$stamp_file" ] \
+     || [ "$dev_image_id" != "$(cat "$stamp_file" 2>/dev/null)" ]; then
+    image_changed=1
   fi
 
-  step "Creating distrobox '$DEV_BOX'..."
-  distrobox create --name "$DEV_BOX" --image "localhost/$DEV_IMAGE" --yes
-  ok "Distrobox created: $DEV_BOX"
-  echo ""
+  local box_exists=0 dbx_list need_recreate=0
+  dbx_list="$(distrobox list 2>/dev/null || true)"
+  if printf '%s\n' "$dbx_list" | grep -F "| $DEVTOOLS_DISTROBOX " >/dev/null 2>&1; then
+    box_exists=1
+  fi
+  if [ "$force_rebuild" = "1" ] || [ "$image_changed" = "1" ] || [ "$box_exists" = "0" ]; then
+    need_recreate=1
+  fi
 
-  step "Running first-entry setup (lux lua tree)..."
-  distrobox enter "$DEV_BOX" -- bash -c '
-    lx install-lua 2>/dev/null
-    LUA_BIN=$(command -v lua-5.1 2>/dev/null || command -v lua5.1 2>/dev/null)
-    if [ -n "$LUA_BIN" ]; then
-      LUX_LUA="$HOME/.local/share/lux/tree/5.1/.lua/bin/lua"
-      mkdir -p "$(dirname "$LUX_LUA")"
-      ln -sf "$LUA_BIN" "$LUX_LUA"
-    fi
-  '
-  ok "Lux lua tree configured"
-  echo ""
+  if [ "$need_recreate" = "1" ]; then
+    distrobox stop --yes "$DEVTOOLS_DISTROBOX" >/dev/null 2>&1 || true
+    distrobox rm -f --yes "$DEVTOOLS_DISTROBOX" >/dev/null 2>&1 \
+      || podman rm -f "$DEVTOOLS_DISTROBOX" >/dev/null 2>&1 \
+      || true
+  fi
 
-  local env_file="$DEVTOOLS_DIR/.env"
-  if grep -q "^DEVTOOLS_DISTROBOX=" "$env_file" 2>/dev/null; then
-    info "DEVTOOLS_DISTROBOX already set in .env"
+  mkdir -p "$(dirname "$stamp_file")"
+  if [ -n "$dev_image_id" ]; then
+    printf '%s\n' "$dev_image_id" > "$stamp_file"
+  fi
+
+  if [ "$need_recreate" = "1" ]; then
+    step "Creating distrobox '$DEVTOOLS_DISTROBOX'..."
+    # localhost/ prefix so distrobox uses the local image instead of pulling from a registry.
+    distrobox create --name "$DEVTOOLS_DISTROBOX" --image "localhost/$DEV_IMAGE" --yes
+    ok "Distrobox created: $DEVTOOLS_DISTROBOX"
   else
-    echo "DEVTOOLS_DISTROBOX=$DEV_BOX" >> "$env_file"
-    ok "Added DEVTOOLS_DISTROBOX=$DEV_BOX to .env"
+    ok "Distrobox '$DEVTOOLS_DISTROBOX' kept (dev image unchanged)."
+  fi
+  echo ""
+
+  export_dev_binaries || warn "Some dev binaries failed to export; recipes / editor that depend on them will need 'just setup::distrobox' rerun."
+  echo ""
+
+  if is_wsl; then
+    cmd_setup_sync_distrobox || warn "bar-sync container build failed; 'just bar::launch' will not be able to mirror edits to /mnt/c."
+    echo ""
   fi
 
-  echo ""
   ok "Distrobox dev environment ready."
   echo ""
-  echo "  Recipes that need lux/node/cargo will now run inside '$DEV_BOX' automatically."
-  echo "  To enter the box manually:  distrobox enter $DEV_BOX"
+  echo "  Recipes that need lux/node/cargo will now run inside '$DEVTOOLS_DISTROBOX' automatically."
+  echo "  To enter the box manually:  distrobox enter $DEVTOOLS_DISTROBOX"
   echo "  To rebuild after changes:   just setup::distrobox"
 }
 
-cmd_init() {
-  local clone_extras=0
-  for arg in "$@"; do
-    case "$arg" in
-      extras|all) clone_extras=1 ;;
+# WSL-only: build + create the bar-sync container hosting the filesystem mirror daemon.
+SYNC_IMAGE="bar-sync"
+cmd_setup_sync_distrobox() {
+  is_wsl || return 0
+
+  # Called on the LHS of `||`, so set -e is off here -- every failure needs an explicit `|| return 1`.
+  step "Building sync container image ($SYNC_IMAGE)..."
+  if ! podman build -t "$SYNC_IMAGE" -f "$DEVTOOLS_DIR/docker/sync.Containerfile" "$DEVTOOLS_DIR"; then
+    err "podman build failed for $SYNC_IMAGE -- see output above for the real cause."
+    return 1
+  fi
+  ok "Image built: $SYNC_IMAGE"
+
+  distrobox stop --yes "$DEVTOOLS_SYNC_DISTROBOX" >/dev/null 2>&1 || true
+  distrobox rm -f --yes "$DEVTOOLS_SYNC_DISTROBOX" >/dev/null 2>&1 \
+    || podman rm -f "$DEVTOOLS_SYNC_DISTROBOX" >/dev/null 2>&1 \
+    || true
+
+  step "Creating distrobox '$DEVTOOLS_SYNC_DISTROBOX'..."
+  if ! distrobox create --name "$DEVTOOLS_SYNC_DISTROBOX" --image "localhost/$SYNC_IMAGE" --yes; then
+    err "distrobox create failed for $DEVTOOLS_SYNC_DISTROBOX."
+    return 1
+  fi
+  ok "Distrobox created: $DEVTOOLS_SYNC_DISTROBOX"
+
+  # Smoke-test pywatchman + watchman before sync.sh relies on them.
+  if ! distrobox enter "$DEVTOOLS_SYNC_DISTROBOX" -- python3 -c \
+       'import pywatchman; pywatchman.client(timeout=5).query("version")' \
+       >/dev/null 2>&1; then
+    err "pywatchman + watchman smoke test failed inside $DEVTOOLS_SYNC_DISTROBOX"
+    return 1
+  fi
+  ok "pywatchman + watchman ready in $DEVTOOLS_SYNC_DISTROBOX"
+}
+
+# Feature -> repo dirs it pulls in (from the loaded repos.conf). Caller must run load_repos_conf first.
+feature_repos() {
+  local feature="$1"
+  local i out=""
+  for i in "${!REPO_DIRS[@]}"; do
+    if features_include "${REPO_FEATURES[$i]}" "$feature"; then
+      out="${out}${REPO_DIRS[$i]} "
+    fi
+  done
+  echo "${out% }"
+}
+
+# Comma-separated features -> deduplicated space-separated repo dirs.
+features_to_repos() {
+  local f r
+  local -a flist=()
+  declare -A seen=()
+  IFS=',' read -ra flist <<< "$1"
+  for f in "${flist[@]}"; do
+    for r in $(feature_repos "$f"); do
+      seen[$r]=1
+    done
+  done
+  echo "${!seen[@]}"
+}
+
+# Interactive checkbox list; items are "key|label|default". Sets CHECKBOX_RESULT, returns 1 on quit.
+checkbox_list() {
+  local title="$1"; shift
+  local -a keys=() labels=() state=()
+  local item
+  for item in "$@"; do
+    keys+=("${item%%|*}")
+    local rest="${item#*|}"
+    labels+=("${rest%|*}")
+    state+=("${rest##*|}")
+  done
+  local n=${#keys[@]}
+  local first=1
+
+  trap 'stty echo 2>/dev/null' EXIT
+  stty -echo 2>/dev/null
+
+  local i mark
+  while true; do
+    if [ "$first" -eq 1 ]; then
+      first=0
+    else
+      printf '\e[%dA' $((n + 4))
+    fi
+    printf '\e[J'
+
+    echo -e "${BOLD}${title}${NC}"
+    echo -e "  ${DIM}1-${n} toggle - a all - n none - enter confirm${NC}"
+    echo ""
+    for ((i=0; i<n; i++)); do
+      [ "${state[i]}" = "1" ] && mark="[${GREEN}x${NC}]" || mark="[ ]"
+      echo -e "  ${DIM}$((i + 1)).${NC} ${mark} ${labels[i]}"
+    done
+    echo ""
+
+    local key=""
+    IFS= read -rsn1 key
+    case "$key" in
+      [1-9])
+        local idx=$((key - 1))
+        if [ "$idx" -lt "$n" ]; then
+          state[idx]=$(( 1 - ${state[idx]:-0} ))
+        fi
+        ;;
+      a|A)       for ((i=0; i<n; i++)); do state[i]=1; done ;;
+      n|N)       for ((i=0; i<n; i++)); do state[i]=0; done ;;
+      ''|$'\n')  break ;;
+      q|Q)       stty echo 2>/dev/null; trap - EXIT; return 1 ;;
     esac
   done
+  stty echo 2>/dev/null
+  trap - EXIT
+
+  local picked=()
+  for ((i=0; i<n; i++)); do
+    [ "${state[i]}" = "1" ] && picked+=("${keys[i]}")
+  done
+  CHECKBOX_RESULT="$(IFS=,; echo "${picked[*]}")"
+  return 0
+}
+
+# yes/no prompt; $2 = default on empty input. 0=yes 1=no.
+ask_yes_no() {
+  local q="$1" def="$2" ans hint
+  [ "$def" = "y" ] && hint="[Y/n]" || hint="[y/N]"
+  read -r -p "$q $hint " ans
+  case "${ans:-$def}" in
+    y|Y|yes|YES) return 0 ;;
+    *)           return 1 ;;
+  esac
+}
+
+# Persist ALLOW_SPRINGSETTINGS_MOD=<0|1> to .env.
+write_springsettings_optin_env() {
+  local choice="$1"   # 1 to opt in, 0 to opt out
+  local env_file="$DEVTOOLS_DIR/.env"
+  touch "$env_file"
+  if grep -q "^ALLOW_SPRINGSETTINGS_MOD=" "$env_file"; then
+    sed -i "s|^ALLOW_SPRINGSETTINGS_MOD=.*|ALLOW_SPRINGSETTINGS_MOD=${choice}|" "$env_file"
+    info "Updated ALLOW_SPRINGSETTINGS_MOD in .env: ${choice}"
+  else
+    echo "ALLOW_SPRINGSETTINGS_MOD=${choice}" >> "$env_file"
+    ok "Added ALLOW_SPRINGSETTINGS_MOD=${choice} to .env"
+  fi
+}
+
+# Ask once whether bar::launch may modify the engine's springsettings.cfg. Default no.
+prompt_springsettings_opt_in() {
+  echo ""
+  echo -e "${BOLD}springsettings.cfg modification opt-in${NC}"
+  echo "  Some bar::launch flags (currently --debug-gl) need to write keys to"
+  echo "  the engine's springsettings.cfg. Without your permission this"
+  echo "  launcher will refuse to touch the file -- the flags will warn and"
+  echo "  no-op. The keys we manage are listed in scripts/launch.sh under"
+  echo "  _MANAGED_SPRINGSETTINGS; nothing else in the cfg is read or written."
+  echo ""
+  local def=n
+  [ "$(read_env_key ALLOW_SPRINGSETTINGS_MOD)" = "1" ] && def=y
+  if ask_yes_no "Allow bar::launch to modify springsettings.cfg for its managed flags?" "$def"; then
+    write_springsettings_optin_env 1
+  else
+    write_springsettings_optin_env 0
+  fi
+}
+
+# 0 if `ssh -T git@github.com` already authenticates. BatchMode prevents a hang on prompts.
+_github_ssh_works() {
+  command -v ssh >/dev/null 2>&1 || return 1
+  local out
+  out="$(ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+              -o ConnectTimeout=5 -T git@github.com 2>&1)"
+  printf '%s' "$out" | grep -q "successfully authenticated"
+}
+
+# Step-0 prompt: pick how SSH to GitHub gets configured. Skips when an agent already authenticates.
+prompt_ssh_setup_choice() {
+  if [ -z "${BAR_RESET_CONFIG:-}" ] && _github_ssh_works; then
+    info "ssh -T git@github.com already authenticates -- skipping ssh setup prompt"
+    write_env_key BAR_SSH_SETUP existing
+    return 0
+  fi
+
+  echo ""
+  echo -e "${BOLD}SSH to GitHub${NC}"
+  echo "  No working SSH agent reaches github.com from this shell. Cloning"
+  echo "  / pushing over HTTPS works but prompts for a token on every push,"
+  echo "  and several BAR-Devtools recipes assume push-by-default. Pick how"
+  echo "  you'd like to set up an SSH key now (we'll run the actual setup"
+  echo "  after the long steps, you don't have to babysit this prompt):"
+  echo ""
+  echo "    1) op      1Password Desktop + agent bridge"
+  echo "    2) manual  Generate ~/.ssh/id_ed25519 + walk through GitHub"
+  echo "    3) skip    Don't configure now (clone over HTTPS; re-run later)"
+  echo ""
+  # Default to the saved choice; existing/skip/unset all land on 3.
+  local cur defnum
+  cur="$(read_env_key BAR_SSH_SETUP)"
+  case "$cur" in
+    op)     defnum=1 ;;
+    manual) defnum=2 ;;
+    *)      defnum=3 ;;
+  esac
+  local ans choice=""
+  while [ -z "$choice" ]; do
+    read -r -p "Choice [1-3] (default ${defnum}): " ans
+    case "${ans:-$defnum}" in
+      1|op)      choice="op" ;;
+      2|manual)  choice="manual" ;;
+      3|skip)    choice="skip" ;;
+      *)         echo "  Invalid choice: ${ans}" ;;
+    esac
+  done
+  write_env_key BAR_SSH_SETUP "$choice"
+  ok "Recorded BAR_SSH_SETUP=$choice in .env"
+}
+
+# Run the SSH setup the user picked at step 0.
+run_ssh_setup_choice() {
+  local env_file="$DEVTOOLS_DIR/.env"
+  local choice
+  choice="$(grep -E "^BAR_SSH_SETUP=" "$env_file" 2>/dev/null | tail -1 | cut -d= -f2-)"
+  case "${choice:-skip}" in
+    op)              bash "$DEVTOOLS_DIR/scripts/ssh/setup-op-ssh.sh"     || warn "ssh::op-setup failed; you can re-run it with 'just ssh::op-setup'." ;;
+    manual)          bash "$DEVTOOLS_DIR/scripts/ssh/setup-manual-ssh.sh" || warn "ssh::manual-setup failed; you can re-run it with 'just ssh::manual-setup'." ;;
+    existing|skip|*) : ;;
+  esac
+  # Export SSH_AUTH_SOCK now so a `git clone` later in this same process can see it.
+  for _sock in "$HOME/.1password/agent.sock" "$HOME/.ssh/agent.sock"; do
+    if [ -S "$_sock" ]; then
+      export SSH_AUTH_SOCK="$_sock"
+      break
+    fi
+  done
+  unset _sock
+}
+
+_EDITOR_RECOMMENDED=(
+  "tangzx.emmylua|EmmyLua (Lua language server)"
+  "JohnnyMorganz.stylua|StyLua (Lua formatter)"
+  "llvm-vs-code-extensions.vscode-clangd|clangd (C/C++ for engine work)"
+)
+# Sets EDITOR_HAVE_CODE / EDITOR_INSTALLED_EXTS / EDITOR_MISSING_EXTS / EDITOR_HAS_SUMNEKO.
+editor_collect_state() {
+  EDITOR_HAVE_CODE=0
+  EDITOR_INSTALLED_EXTS=""
+  EDITOR_MISSING_EXTS=""
+  EDITOR_HAS_SUMNEKO=0
+  command -v code >/dev/null 2>&1 || return 0
+  EDITOR_HAVE_CODE=1
+  EDITOR_INSTALLED_EXTS="$(code --list-extensions 2>/dev/null || true)"
+  grep -qixF sumneko.lua <<<"$EDITOR_INSTALLED_EXTS" && EDITOR_HAS_SUMNEKO=1
+  local entry ext miss=""
+  for entry in "${_EDITOR_RECOMMENDED[@]}"; do
+    ext="${entry%%|*}"
+    grep -qixF "$ext" <<<"$EDITOR_INSTALLED_EXTS" || miss="${miss} ${ext}"
+  done
+  EDITOR_MISSING_EXTS="${miss# }"
+}
+
+# Render the recommended-extensions list. Caller runs editor_collect_state first.
+_editor_render_state() {
+  local entry ext label
+  for entry in "${_EDITOR_RECOMMENDED[@]}"; do
+    ext="${entry%%|*}"; label="${entry#*|}"
+    if [ "${EDITOR_HAVE_CODE:-0}" = "1" ] && grep -qixF "$ext" <<<"$EDITOR_INSTALLED_EXTS"; then
+      printf "  ${CYAN}✓${NC} %-40s %s ${DIM}(installed)${NC}\n" "$ext" "$label"
+    elif [ "${EDITOR_HAVE_CODE:-0}" = "1" ]; then
+      printf "  ${RED}✗${NC} %-40s %s ${DIM}(missing)${NC}\n"   "$ext" "$label"
+    else
+      printf "  ${DIM}?${NC} %-40s %s\n"                        "$ext" "$label"
+    fi
+  done
+  # if/then/fi (not `&&`) so the function returns 0 under set -e when sumneko is absent.
+  if [ "${EDITOR_HAS_SUMNEKO:-0}" = "1" ]; then
+    printf "  ${YELLOW}!${NC} %-40s ${DIM}(installed; conflicts with tangzx.emmylua)${NC}\n" "sumneko.lua"
+  fi
+}
+
+# Editor-integration preamble, shared by the Step 0/N prompt and the standalone editor recipe.
+_editor_show_preamble() {
+  echo ""
+  echo -e "${BOLD}Editor integration${NC}"
+  echo "  Wires up your editor (VS Code, Cursor, VSCodium -- anything that finds"
+  echo "  language servers on PATH) for BAR development:"
+  echo "    - exports emmylua_ls, emmylua_check, clangd, stylua, lx to ~/.local/bin"
+  echo "    - generates RecoilEngine/compile_commands.json for clangd"
+  echo "    - writes Beyond-All-Reason/.vscode/settings.json (gitignored, per-checkout)"
+  echo ""
+  if [ "${EDITOR_HAVE_CODE:-0}" = "1" ]; then
+    echo "  Detected: 'code' on PATH. Recommended VS Code extensions:"
+    _editor_render_state
+  else
+    info "  'code' is not on PATH. Wiring still works for Cursor / non-vscode editors,"
+    info "  but extensions can't be auto-installed -- handle them in your editor's UI."
+  fi
+  echo ""
+}
+
+# Editor opt-in prompt. Persists BAR_EDITOR_SETUP=yes|no.
+prompt_editor_setup_choice() {
+  editor_collect_state
+  _editor_show_preamble
+
+  local def=y
+  [ "$(read_env_key BAR_EDITOR_SETUP)" = "no" ] && def=n
+  if ask_yes_no "Wire up editor integration after the build?" "$def"; then
+    write_env_key BAR_EDITOR_SETUP yes
+  else
+    write_env_key BAR_EDITOR_SETUP no
+  fi
+}
+
+# Run cmd_setup_editor if BAR_EDITOR_SETUP says yes.
+run_editor_setup_choice() {
+  local env_file="$DEVTOOLS_DIR/.env"
+  local choice
+  choice="$(grep -E "^BAR_EDITOR_SETUP=" "$env_file" 2>/dev/null | tail -1 | cut -d= -f2-)"
+  case "${choice:-no}" in
+    yes) cmd_setup_editor ;;
+    *)   info "Editor integration skipped (declined at configuration step)." ;;
+  esac
+}
+
+# Unattended editor wiring: installs recommended extensions, removes a conflicting sumneko.lua.
+cmd_setup_editor() {
+  if [ -z "${DEVTOOLS_DISTROBOX:-}" ]; then
+    err "DEVTOOLS_DISTROBOX not set. Run: just setup::distrobox"
+    return 1
+  fi
+
+  # Dev binaries are exported by setup::distrobox; bail loudly if they're missing.
+  local local_bin="$HOME/.local/bin" bin missing_bins=()
+  for bin in emmylua_ls emmylua_check clangd stylua lx; do
+    [ -x "$local_bin/$bin" ] || missing_bins+=("$bin")
+  done
+  if [ "${#missing_bins[@]}" -gt 0 ]; then
+    err "Dev binary wrappers missing in $local_bin: ${missing_bins[*]}"
+    err "  These are exported by setup::distrobox. Run: just setup::distrobox"
+    return 1
+  fi
+
+  if [ -f "$DEVTOOLS_DIR/RecoilEngine/CMakeLists.txt" ]; then
+    step "Generating compile_commands.json for clangd..."
+    # set -eo pipefail inside so `| tail -3` doesn't swallow a cmake failure.
+    if ! distrobox enter "$DEVTOOLS_DISTROBOX" -- bash -c "
+      set -eo pipefail
+      cd '$DEVTOOLS_DIR/RecoilEngine' \
+        && mkdir -p build \
+        && cd build \
+        && cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .. 2>&1 | tail -3
+    "; then
+      err "cmake configure failed; compile_commands.json not generated."
+      err "  Re-run 'just setup::editor' once the engine builds cleanly."
+      return 1
+    fi
+    if [ ! -f "$DEVTOOLS_DIR/RecoilEngine/build/compile_commands.json" ]; then
+      err "cmake reported success but build/compile_commands.json is missing."
+      return 1
+    fi
+    ln -sf build/compile_commands.json "$DEVTOOLS_DIR/RecoilEngine/compile_commands.json"
+    ok "compile_commands.json ready"
+  else
+    info "RecoilEngine not cloned -- skipping compile_commands.json"
+  fi
+  echo ""
+
+  editor_collect_state
+  if [ "$EDITOR_HAVE_CODE" = "1" ] && [ -n "$EDITOR_MISSING_EXTS" ]; then
+    local ext
+    for ext in $EDITOR_MISSING_EXTS; do
+      code --install-extension "$ext" --force >/dev/null
+      info "Installed $ext"
+    done
+    echo ""
+  fi
+
+  if [ "$EDITOR_HAS_SUMNEKO" = "1" ]; then
+    code --uninstall-extension sumneko.lua >/dev/null
+    ok "sumneko.lua uninstalled (conflicts with tangzx.emmylua)"
+    echo ""
+  fi
+
+  info "Binaries exported to ~/.local/bin (by setup::distrobox):"
+  for bin in emmylua_ls emmylua_check clangd stylua lx; do
+    if [ -x "$HOME/.local/bin/$bin" ]; then
+      printf "  ${CYAN}✓ %s${NC}\n" "$bin"
+    else
+      printf "  ${RED}✗ %s${NC}  ${DIM}(missing -- rerun setup::distrobox)${NC}\n" "$bin"
+    fi
+  done
+  echo ""
+
+  # Per-checkout .vscode/settings.json; the engine template bakes in $HOME for clangd.path.
+  _write_vscode_settings() {
+    local repo="$1" template="$2"
+    local dest="$DEVTOOLS_DIR/$repo/.vscode/settings.json"
+    [ -d "$DEVTOOLS_DIR/$repo" ] || return 0
+    local rendered
+    rendered="$(sed "s|__HOME__|$HOME|g" "$template")"
+    if [ ! -f "$dest" ]; then
+      mkdir -p "$(dirname "$dest")"
+      printf '%s\n' "$rendered" > "$dest"
+      ok "Wrote $dest"
+    elif ! diff -q <(printf '%s\n' "$rendered") "$dest" >/dev/null 2>&1; then
+      warn "$dest differs from recommended defaults:"
+      diff -u "$dest" <(printf '%s\n' "$rendered") | sed 's/^/  /' || true
+      info "Merge by hand (or delete the file and re-run 'just setup::editor')."
+    else
+      info "$dest matches recommended defaults"
+    fi
+  }
+  _write_vscode_settings "Beyond-All-Reason" "$DEVTOOLS_DIR/templates/bar-vscode-settings.json"
+  _write_vscode_settings "RecoilEngine"      "$DEVTOOLS_DIR/templates/recoil-vscode-settings.json"
+  unset -f _write_vscode_settings
+  echo ""
+  ok "Editor integration ready."
+  echo ""
+  info "If your editor was already open, reload the window (or run"
+  info "'EmmyLua: Restart Server' and 'clangd: Restart language server')"
+  info "so both extensions pick up the new binaries."
+}
+
+# Clone only the repos that map to the selected features.
+clone_for_features() {
+  local features="$1"
+  if [ -z "$features" ]; then
+    return 0
+  fi
+  load_repos_conf
+  local wanted
+  wanted="$(features_to_repos "$features")"
+
+  echo -e "${BOLD}=== Cloning repositories for: ${features} ===${NC}"
+  echo ""
+
+  if [ -f "$REPOS_LOCAL" ]; then
+    info "Using overrides from repos.local.conf"
+    echo ""
+  fi
+
+  local i cloned=0 updated=0 linked=0 pruned=0
+  for i in "${!REPO_DIRS[@]}"; do
+    local dir="${REPO_DIRS[$i]}"
+    if [[ " $wanted " != *" $dir "* ]]; then
+      # Deselected: drop a workspace symlink, or move a real clone to .backups/ (never delete).
+      local target="$DEVTOOLS_DIR/$dir"
+      if [ -L "$target" ]; then
+        info "  ${dir}: deselected -- removing workspace symlink ($(readlink "$target") kept)"
+        rm "$target"
+        pruned=$((pruned + 1))
+      elif [ -d "$target" ]; then
+        local backup="$DEVTOOLS_DIR/.backups/${dir}-$(date +%Y%m%d-%H%M%S)"
+        warn "  ${dir}: deselected -- moving workspace copy to ${backup}"
+        mkdir -p "$DEVTOOLS_DIR/.backups"
+        mv "$target" "$backup"
+        pruned=$((pruned + 1))
+      fi
+      continue
+    fi
+
+    local local_path="${REPO_LOCAL_PATHS[$i]}"
+    local upstream_url="${REPO_UPSTREAM_URLS[$i]}"
+    if [ -n "$local_path" ]; then
+      clone_or_update_repo "$dir" "${REPO_URLS[$i]}" "${REPO_BRANCHES[$i]}" "$upstream_url" "$local_path"
+      linked=$((linked + 1))
+    elif [ -d "$DEVTOOLS_DIR/$dir/.git" ]; then
+      clone_or_update_repo "$dir" "${REPO_URLS[$i]}" "${REPO_BRANCHES[$i]}" "$upstream_url"
+      updated=$((updated + 1))
+    else
+      clone_or_update_repo "$dir" "${REPO_URLS[$i]}" "${REPO_BRANCHES[$i]}" "$upstream_url"
+      cloned=$((cloned + 1))
+    fi
+  done
+
+  echo ""
+  local summary="${cloned} cloned, ${updated} updated"
+  [ "$linked" -gt 0 ] && summary+=", ${linked} linked"
+  [ "$pruned" -gt 0 ] && summary+=", ${pruned} pruned"
+  ok "Repos: ${summary}"
+}
+
+# status recap collected through cmd_init; rendered at the end
+SETUP_RECAP=()
+recap() { SETUP_RECAP+=("$1|$2|$3"); }   # label|status(ok|skip|warn)|detail
+
+render_setup_recap() {
+  local entry label status detail glyph color
+  for entry in "${SETUP_RECAP[@]}"; do
+    IFS='|' read -r label status detail <<<"$entry"
+    case "$status" in
+      ok)   glyph="✓"; color="$GREEN" ;;
+      skip) glyph="∘"; color="$DIM" ;;
+      warn) glyph="⚠"; color="$YELLOW" ;;
+      *)    glyph="·"; color="$NC" ;;
+    esac
+    printf '  %b%s %-16s%b %b%s%b\n' "$color" "$glyph" "$label" "$NC" "$DIM" "$detail" "$NC"
+  done
+}
+
+cmd_init() {
+  require_host
+  SETUP_RECAP=()
 
   echo -e "${BOLD}==========================================${NC}"
   echo -e "${BOLD}  BAR Dev Environment - First Time Setup${NC}"
   echo -e "${BOLD}==========================================${NC}"
   echo ""
 
-  step "1/6  Checking & installing dependencies"
-  echo ""
-  local deps_ok=0
-  if check_git &>/dev/null && check_docker &>/dev/null; then
-    deps_ok=1
-    ok "Core dependencies (git, docker) already installed."
-  else
-    cmd_install_deps || { err "Dependency installation failed. Fix and retry."; exit 1; }
-    deps_ok=1
-  fi
-  echo ""
+  # apt-shipped just 1.21 silently mis-parses our module syntax.
+  _check_just_min_version "1.31.0"
 
-  step "2/6  Dev environment (distrobox)"
-  echo ""
-  if [ -n "${DEVTOOLS_DISTROBOX:-}" ]; then
-    ok "Distrobox already configured: $DEVTOOLS_DISTROBOX"
-  elif command -v distrobox &>/dev/null; then
-    read -rp "Set up a distrobox dev environment? (recommended) [Y/n] " setup_box
-    if [[ ! "$setup_box" =~ ^[Nn]$ ]]; then
-      cmd_setup_distrobox
-    fi
-  else
-    info "distrobox not installed -- skipping dev environment setup."
-    info "Install distrobox and run 'just setup::distrobox' later for the full toolchain."
-  fi
-  echo ""
+  ensure_wsl_setup
 
-  step "3/6  Cloning repositories"
-  echo ""
+  # Front-load all interactive decisions so the user can answer and walk away.
   if [ ! -f "$REPOS_CONF" ]; then
     err "repos.conf not found at: $REPOS_CONF"
     exit 1
   fi
-  cmd_clone core
-  echo ""
 
-  if [ "$clone_extras" -eq 1 ]; then
-    cmd_clone extra
-    echo ""
-  else
-    read -rp "Also clone extra repositories (game engine, SPADS source, infra)? [y/N] " extras
-    if [[ "$extras" =~ ^[Yy]$ ]]; then
-      cmd_clone extra
-      echo ""
-    fi
+  step "0/8  Configuration"
+  echo ""
+  if is_wsl; then
+    ensure_bar_data_dir || warn "Skipping BAR data dir setup (set BAR_DATA_DIR in .env to retry)."
   fi
 
-  step "4/6  Building Docker images"
-  echo ""
-  install_dockerignore
-  info "Building Docker images..."
-  $COMPOSE build teiserver
-  $COMPOSE --profile spads pull spads
-  ok "Images built successfully."
-  echo ""
-
-  if [ -d "$DEVTOOLS_DIR/RecoilEngine/docker-build-v2" ]; then
-    step "5/6  Engine build"
-    echo ""
-    read -rp "Build engine from source? [y/N] " build_engine
-    if [[ "$build_engine" =~ ^[Yy]$ ]]; then
-      local engine_arch
-      case "$(uname -m)" in
-        x86_64)       engine_arch="amd64" ;;
-        aarch64|arm64) engine_arch="arm64" ;;
-        *)            engine_arch="amd64" ;;
-      esac
-      info "Building Recoil engine (${engine_arch}-linux, this may take a while)..."
-      bash "$DEVTOOLS_DIR/RecoilEngine/docker-build-v2/build.sh" --arch "$engine_arch" linux
-    fi
-    echo ""
-  else
-    step "5/6  Engine build"
-    echo ""
-    info "RecoilEngine not cloned -- skipping. Clone with: just repos::clone extra"
-    echo ""
+  ensure_module_by_name features || true
+  local features
+  features="$(read_env_key BAR_FEATURES)"
+  if [ -z "$features" ]; then
+    info "Skipping clone/build steps. Re-run 'just setup::init' to pick components."
+    return 0
   fi
 
-  step "6/6  Symlinks to game directory"
-  echo ""
-  local game_dir
+  # Remaining modules are feature-gated via module_relevant.
+  # Symlink decision is captured now; actual linking happens in step 6.
+  local game_dir do_link
+  if module_relevant link_on_build; then
+    ensure_module_by_name link_on_build
+  fi
   game_dir="$(detect_game_dir 2>/dev/null)" || true
-  if [ -z "$game_dir" ]; then
-    info "No game directory detected. Set BAR_GAME_DIR to enable linking."
-    echo ""
-  else
-    local available=()
-    [ -d "$DEVTOOLS_DIR/RecoilEngine" ] && available+=("engine")
-    [ -d "$DEVTOOLS_DIR/BYAR-Chobby" ] && available+=("chobby")
-    [ -d "$DEVTOOLS_DIR/Beyond-All-Reason" ] && available+=("bar")
+  do_link="$(read_env_key BAR_LINK_ON_BUILD)"
 
-    if [ "${#available[@]}" -gt 0 ]; then
-      echo "  Available repos to symlink into $game_dir:"
-      for name in "${available[@]}"; do
-        case "$name" in
-          engine) echo -e "    ${BOLD}engine${NC}  -> $game_dir/engine/local-build/" ;;
-          chobby) echo -e "    ${BOLD}chobby${NC}  -> $game_dir/games/BYAR-Chobby/" ;;
-          bar)    echo -e "    ${BOLD}bar${NC}     -> $game_dir/games/Beyond-All-Reason/" ;;
-        esac
-      done
-      echo ""
-      warn "This will replace any existing directories at these paths with symlinks."
-      read -rp "Symlink all? [y/N] " do_link
-      if [[ "$do_link" =~ ^[Yy]$ ]]; then
-        BAR_GAME_DIR="$game_dir"
-        for name in "${available[@]}"; do
-          cmd_link "$name"
-        done
-      fi
-    else
-      info "No linkable repos cloned yet."
-    fi
+  if module_relevant chobby_channel; then ensure_module_by_name chobby_channel || true; fi
+  if module_relevant springsettings; then ensure_module_by_name springsettings || true; fi
+  ensure_module_by_name ssh             || true
+  # editor's apply is deferred to step 8 -- distrobox-export needs the container from step 2.
+  if module_relevant editor; then ensure_module_by_name editor || true; fi
+  echo ""
+
+  confirm_setup_plan "$features" "$game_dir" "$do_link"
+
+  step "1/8  Checking & installing dependencies"
+  echo ""
+  if check_git &>/dev/null && check_podman &>/dev/null; then
+    ok "Core dependencies (git, podman) already installed."
+    recap "Dependencies" ok "already installed"
+  else
+    cmd_install_deps || { err "Dependency installation failed. Fix and retry."; exit 1; }
+    recap "Dependencies" ok "installed"
+  fi
+  ensure_windows_python
+  ensure_sync_daemon_deps_wsl
+  echo ""
+
+  step "2/8  Dev environment (distrobox -- required)"
+  echo ""
+  cmd_setup_distrobox
+  recap "Dev container" ok "$DEVTOOLS_DISTROBOX ready"
+  echo ""
+
+  step "3/8  Cloning repositories"
+  echo ""
+  clone_for_features "$features"
+  recap "Repositories" ok "cloned"
+  echo ""
+
+  if feature_selected bar; then
+    ( cd "$DEVTOOLS_DIR" && just bar::lux-install ) \
+      || warn "Lux install failed; run 'just bar::lux-install' once the tree settles."
+    echo ""
+  fi
+
+  step "4/8  Building Docker images"
+  echo ""
+  if feature_selected teiserver; then
+    install_dockerignore
+    info "Building Docker images..."
+    $COMPOSE build teiserver
+    $COMPOSE --profile spads pull spads
+    ok "Images built successfully."
+    recap "Docker images" ok "built"
+  else
+    info "Teiserver not selected -- skipping Docker image build."
+    recap "Docker images" skip "teiserver not selected"
   fi
   echo ""
 
-  echo -e "${BOLD}=== Setup Complete ===${NC}"
+  step "5/8  Engine build"
   echo ""
-  echo "  Your workspace is ready. Next steps:"
+  if feature_selected recoil; then
+    if [ -d "$DEVTOOLS_DIR/RecoilEngine/docker-build-v2" ]; then
+      local engine_arch engine_os="linux"
+      case "$(uname -m)" in
+        x86_64)        engine_arch="amd64" ;;
+        aarch64|arm64) engine_arch="arm64" ;;
+        *)             engine_arch="amd64" ;;
+      esac
+      is_wsl && engine_os="windows"
+      info "Building Recoil engine (${engine_arch}-${engine_os}, this may take a while)..."
+      # Via `just engine::build` so the post-success sync.sh mirror-engine hook fires.
+      ( cd "$DEVTOOLS_DIR" && just engine::build --arch "$engine_arch" "$engine_os" )
+      recap "Engine build" ok "${engine_arch}-${engine_os}"
+    else
+      warn "Recoil selected but RecoilEngine/docker-build-v2 missing -- clone may have failed."
+      recap "Engine build" warn "RecoilEngine missing"
+    fi
+  else
+    info "Recoil not selected -- skipping engine build."
+    recap "Engine build" skip "recoil not selected"
+  fi
   echo ""
-  echo -e "    ${BOLD}just services::up${NC}             Start Teiserver + PostgreSQL"
-  echo -e "    ${BOLD}just services::up lobby${NC}       ...and launch bar-lobby"
-  echo -e "    ${BOLD}just services::up spads${NC}       ...and start SPADS autohost"
-  echo -e "    ${BOLD}just engine::build linux${NC}      Build the Recoil engine"
+
+  step "6/8  Symlinks to game directory"
+  echo ""
+  if [ -z "$game_dir" ]; then
+    info "No game directory detected. Set BAR_DATA_DIR to enable linking."
+    recap "Symlinks" skip "no game dir"
+  elif [ "$do_link" = "yes" ]; then
+    local spec feat dir name link_n=0 link_warn=0
+    BAR_DATA_DIR="$game_dir"
+    for spec in "recoil:RecoilEngine:engine" "chobby:BYAR-Chobby:chobby" "bar:Beyond-All-Reason:bar"; do
+      IFS=: read -r feat dir name <<<"$spec"
+      feature_selected "$feat" || continue
+      if [ -d "$DEVTOOLS_DIR/$dir" ]; then
+        cmd_link "$name"
+        link_n=$((link_n + 1))
+      else
+        warn "  ${feat} selected but ${dir} not present -- skipping link (clone may have failed)"
+        link_warn=1
+      fi
+    done
+    if [ "$link_warn" -eq 1 ]; then
+      recap "Symlinks" warn "${link_n} linked, some missing"
+    else
+      recap "Symlinks" ok "${link_n} linked"
+    fi
+
+    # WSL2: pre-warm the cold-copy seed so the first bar::launch hits the fast incremental path.
+    if is_wsl; then
+      echo ""
+      info "Pre-warming sync state (cold-copy of source pairs to $BAR_DATA_DIR)"
+      bash "$DEVTOOLS_DIR/scripts/sync.sh" cold-copy \
+        || warn "Pre-warm failed; first 'just bar::launch' will fall back to a full rsync seed."
+    fi
+  else
+    info "Skipping symlinks (declined at configuration step)."
+    recap "Symlinks" skip "declined"
+  fi
+  echo ""
+
+  step "7/8  bar-launch venv (just bar::launch)"
+  echo ""
+  if is_wsl; then
+    ensure_bar_launch_venv_windows && regenerate_bar_launch_cmd_shim
+  else
+    cmd_setup_bar_launch
+  fi
+  recap "bar-launch venv" ok "ready"
+  echo ""
+
+  step "8/8  Deferred module apply (editor, etc.)"
+  echo ""
+  apply_deferred_modules
+  recap "Editor wiring" ok "applied"
+  echo ""
+
+  local feat_n
+  feat_n="$(awk -F, '{print NF}' <<<"$features")"
+  echo -e "${GREEN}${BOLD}✔ Setup complete${NC} ${DIM}— ${feat_n} feature(s) ready${NC}"
+  echo ""
+  render_setup_recap
+  echo ""
+  local f feat_line=""
+  for f in ${features//,/ }; do feat_line+="  ${GREEN}✓${NC} ${f}"; done
+  echo -e "${feat_line}"
+  echo ""
+  echo -e "  ${BOLD}Your workspace is ready.${NC} Next steps:"
+  echo ""
+  if feature_selected teiserver; then
+    echo -e "  ${CYAN}Teiserver${NC}"
+    echo -e "    ${BOLD}just services::up${NC}             Start Teiserver + PostgreSQL"
+    echo -e "    ${BOLD}just services::up spads${NC}       ...and start SPADS autohost"
+    echo ""
+  fi
+  if feature_selected bar; then
+    echo -e "  ${CYAN}BAR (game content)${NC}"
+    echo -e "    ${BOLD}just bar::launch${NC}              Launch the engine against your local checkout"
+    echo -e "    ${BOLD}just services::up lobby${NC}       Launch bar-lobby and connect"
+    echo -e "    ${BOLD}just bar::units${NC}               Run busted Lua unit tests"
+    echo -e "    ${BOLD}just bar::units-shell${NC}         Drop into an interactive busted shell"
+    echo -e "    ${BOLD}just bar::lx-shell${NC}            Drop into an lx shell for package work"
+    echo -e "    ${BOLD}just bar::check${NC}               EmmyLua type-check across the repo"
+    echo -e "    ${BOLD}just bar::lint${NC}                luacheck (via lux)"
+    echo -e "    ${BOLD}just bar::fmt${NC}                 stylua format"
+    echo -e "    ${BOLD}just bar::integrations${NC}        Headless integration tests (x86-64 only)"
+    echo -e "    ${BOLD}just bar::setup-hooks${NC}         Install the stylua pre-commit hook"
+    echo -e "    ${DIM}Edits land in Beyond-All-Reason/ and reflect live via the symlink.${NC}"
+    echo ""
+  fi
+  if feature_selected chobby && ! feature_selected bar; then
+    echo -e "  ${CYAN}Chobby${NC}"
+    echo -e "    ${BOLD}just services::up lobby${NC}       Launch bar-lobby (loads BYAR-Chobby)"
+    echo ""
+  fi
+  if feature_selected recoil; then
+    echo -e "  ${CYAN}Recoil${NC}"
+    if is_wsl; then
+      echo -e "    ${BOLD}just engine::build windows${NC}    Rebuild the engine"
+    else
+      echo -e "    ${BOLD}just engine::build linux${NC}      Rebuild the engine"
+    fi
+    echo ""
+  fi
+  if feature_selected spads-source; then
+    echo -e "  ${CYAN}SPADS source${NC}"
+    echo -e "    ${DIM}see SPADS/ and SpringLobbyInterface/ for autohost dev${NC}"
+    echo ""
+  fi
+  echo -e "  ${CYAN}Workspace${NC}"
   echo -e "    ${BOLD}just link::status${NC}             Show symlink status"
   echo -e "    ${BOLD}just repos::status${NC}            Show repository status"
   echo ""
@@ -410,23 +1918,27 @@ cmd_init() {
 }
 
 cmd_setup() {
+  require_host
+
   echo -e "${BOLD}=== BAR Dev Environment Setup ===${NC}"
   echo ""
   check_prerequisites || exit 1
 
-  local missing_core=0
+  # Auto-clone the teiserver feature repos if any are missing.
+  local missing_teiserver=0
   load_repos_conf
   for i in "${!REPO_DIRS[@]}"; do
-    if [ "${REPO_GROUPS[$i]}" = "core" ] && [ ! -d "$DEVTOOLS_DIR/${REPO_DIRS[$i]}/.git" ]; then
-      missing_core=1
+    if features_include "${REPO_FEATURES[$i]}" "teiserver" \
+       && [ ! -d "$DEVTOOLS_DIR/${REPO_DIRS[$i]}/.git" ]; then
+      missing_teiserver=1
       break
     fi
   done
 
-  if [ "$missing_core" -eq 1 ]; then
-    warn "Core repositories are missing. Cloning them now..."
+  if [ "$missing_teiserver" -eq 1 ]; then
+    warn "Teiserver repositories are missing. Cloning them now..."
     echo ""
-    cmd_clone core
+    cmd_clone teiserver
     echo ""
   fi
 
@@ -444,15 +1956,37 @@ cmd_setup() {
 }
 
 detect_game_dir() {
-  if [ -n "${BAR_GAME_DIR:-}" ]; then
-    echo "$BAR_GAME_DIR"
+  if [ -n "${BAR_DATA_DIR:-}" ]; then
+    echo "$BAR_DATA_DIR"
     return 0
   fi
+
+  # WSL2: the sync-target data dir, not the upstream installer's (which has no Devtools content).
+  if is_wsl; then
+    local data_dir
+    data_dir="$(bar_data_dir_get)"
+    if [ -n "$data_dir" ] && [ -d "$data_dir" ]; then
+      echo "$data_dir"
+      return 0
+    fi
+  fi
+
   local xdg_state="${XDG_STATE_HOME:-$HOME/.local/state}"
   local candidate="$xdg_state/Beyond All Reason"
   if [ -d "$candidate" ]; then
     echo "$candidate"
     return 0
+  fi
+  if is_wsl && command -v wslpath &>/dev/null && command -v cmd.exe &>/dev/null; then
+    local win_userprofile
+    win_userprofile="$(cmd.exe /c 'echo %USERPROFILE%' 2>/dev/null | tr -d '\r\n')"
+    if [ -n "$win_userprofile" ]; then
+      candidate="$(wslpath "$win_userprofile")/AppData/Local/Programs/Beyond-All-Reason/data"
+      if [ -d "$candidate" ]; then
+        echo "$candidate"
+        return 0
+      fi
+    fi
   fi
   return 1
 }
@@ -466,17 +2000,18 @@ cmd_link() {
     echo -e "${BOLD}=== Symlink Status ===${NC}"
     echo ""
     if [ -z "$game_dir" ]; then
-      warn "Game directory not found. Set BAR_GAME_DIR env var or install BAR to the default location."
+      warn "Game directory not found. Set BAR_DATA_DIR env var or install BAR to the default location."
       echo ""
       return 0
     fi
     info "Game directory: ${game_dir}"
     echo ""
 
+    # .sdd suffix required: spring's archive scanner won't register a dir without it.
     local -A link_map=(
       [engine]="$game_dir/engine/local-build"
-      [chobby]="$game_dir/games/BYAR-Chobby"
-      [bar]="$game_dir/games/Beyond-All-Reason"
+      [chobby]="$game_dir/games/BYAR-Chobby.sdd"
+      [bar]="$game_dir/games/Beyond-All-Reason.sdd"
     )
     for name in engine chobby bar; do
       local link_path="${link_map[$name]}"
@@ -495,23 +2030,32 @@ cmd_link() {
   fi
 
   if [ -z "$game_dir" ]; then
-    err "Game directory not found. Set BAR_GAME_DIR env var or install BAR to the default location."
+    err "Game directory not found. Set BAR_DATA_DIR env var or install BAR to the default location."
     exit 1
   fi
+
+  ensure_devmode_marker "$game_dir"
 
   local source_path link_path
   case "$target" in
     engine)
-      source_path="$DEVTOOLS_DIR/RecoilEngine/build-linux/install"
+      local engine_arch engine_os="linux"
+      case "$(uname -m)" in
+        x86_64)        engine_arch="amd64" ;;
+        aarch64|arm64) engine_arch="arm64" ;;
+        *)             engine_arch="amd64" ;;
+      esac
+      is_wsl && engine_os="windows"
+      source_path="$DEVTOOLS_DIR/RecoilEngine/build-${engine_arch}-${engine_os}/install"
       link_path="$game_dir/engine/local-build"
       ;;
     chobby)
       source_path="$DEVTOOLS_DIR/BYAR-Chobby"
-      link_path="$game_dir/games/BYAR-Chobby"
+      link_path="$game_dir/games/BYAR-Chobby.sdd"
       ;;
     bar)
       source_path="$DEVTOOLS_DIR/Beyond-All-Reason"
-      link_path="$game_dir/games/Beyond-All-Reason"
+      link_path="$game_dir/games/Beyond-All-Reason.sdd"
       ;;
     *)
       err "Unknown link target: $target"
@@ -523,11 +2067,28 @@ cmd_link() {
   if [ ! -e "$source_path" ] && [ ! -L "$source_path" ]; then
     err "Source not found: $source_path"
     if [ "$target" = "engine" ]; then
-      echo "  Build the engine first: just engine::build linux"
+      if is_wsl; then
+        echo "  Build the engine first: just engine::build windows"
+      else
+        echo "  Build the engine first: just engine::build linux"
+      fi
     else
-      echo "  Clone the repo first: just repos::clone extra"
+      echo "  Clone the repo first: just repos::clone $target"
     fi
     exit 1
+  fi
+
+  # WSL2: no symlink -- the sync daemon mirrors source_path to link_path. Just create the target dir.
+  if is_wsl; then
+    if [ ! -d "$source_path" ]; then
+      err "Source not present at $source_path -- can't register sync target."
+      return 1
+    fi
+    mkdir -p "$link_path"
+    info "WSL2: $target tracks $source_path -> $link_path (via sync daemon)"
+    info "  Mirror updates run via the sync daemon (seeded by setup::init or bar::launch)."
+    ok "Tracked $target: $link_path (mirrors $source_path)"
+    return 0
   fi
 
   if [ -L "$link_path" ]; then
@@ -543,3 +2104,8 @@ cmd_link() {
   ln -s "$source_path" "$link_path"
   ok "Linked $target: $link_path -> $source_path"
 }
+
+# Load the setup module registry. MUST run after every setup.sh helper is defined.
+# shellcheck source=scripts/setup/_lib.sh
+source "$DEVTOOLS_DIR/scripts/setup/_lib.sh"
+_load_setup_modules

--- a/scripts/setup/20-features.sh
+++ b/scripts/setup/20-features.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# shellcheck source=scripts/setup/_lib.sh
+# Module: features.
+
+prompt_features() {
+    CHECKBOX_RESULT=""
+    # `for` order must match the checkbox_list args below
+    local cur f init=()
+    cur="$(read_env_key BAR_FEATURES)"
+    for f in bar recoil teiserver chobby spads-source; do
+        if [ -n "$cur" ]; then
+            features_include "$cur" "$f" && init+=(1) || init+=(0)
+        elif [ "$f" = "spads-source" ]; then
+            init+=(0)
+        else
+            init+=(1)
+        fi
+    done
+    if ! checkbox_list "Which BAR components will you work on?" \
+        "bar|BAR game content + bar-lobby client|${init[0]}" \
+        "recoil|Recoil engine (build from source)|${init[1]}" \
+        "teiserver|Teiserver (lobby/matchmaking server)|${init[2]}" \
+        "chobby|Chobby (in-game lobby)|${init[3]}" \
+        "spads-source|SPADS source (autohost dev, optional)|${init[4]}"
+    then
+        warn "Selection cancelled."
+        return 1
+    fi
+    if [ -z "$CHECKBOX_RESULT" ]; then
+        warn "No features selected. Nothing to clone or build."
+        return 1
+    fi
+    write_env_key BAR_FEATURES "$CHECKBOX_RESULT"
+    ok "Selected: $CHECKBOX_RESULT"
+}
+
+apply_features() {
+    :
+}
+
+register_module features BAR_FEATURES prompt_features apply_features

--- a/scripts/setup/25-link-on-build.sh
+++ b/scripts/setup/25-link-on-build.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# shellcheck source=scripts/setup/_lib.sh
+# Module: link_on_build.
+
+prompt_link_on_build() {
+    local game_dir
+    game_dir="$(detect_game_dir 2>/dev/null)" || true
+    if [ -z "$game_dir" ]; then
+        info "link_on_build: no game directory detected; will skip symlinking."
+        write_env_key BAR_LINK_ON_BUILD "no"
+        return 0
+    fi
+    info "Game directory detected: $game_dir"
+    warn "Symlinking will replace any existing engine/chobby/bar dirs there."
+    local def=n
+    [ "$(read_env_key BAR_LINK_ON_BUILD)" = "yes" ] && def=y
+    if ask_yes_no "Symlink all selected components into the game dir after build?" "$def"; then
+        write_env_key BAR_LINK_ON_BUILD "yes"
+    else
+        write_env_key BAR_LINK_ON_BUILD "no"
+    fi
+}
+
+apply_link_on_build() {
+    :
+}
+
+summary_link_on_build() {
+    if [ "$(read_env_key BAR_LINK_ON_BUILD)" = "yes" ]; then
+        echo "symlink selected repos into the game directory after build"
+    else
+        echo "no game-directory symlinks"
+    fi
+}
+
+register_module link_on_build BAR_LINK_ON_BUILD prompt_link_on_build apply_link_on_build config bar,recoil,chobby

--- a/scripts/setup/30-chobby-channel.sh
+++ b/scripts/setup/30-chobby-channel.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# shellcheck source=scripts/setup/_lib.sh
+# Module: chobby_channel.
+
+# shellcheck source=scripts/chobby-channel.sh
+source "$DEVTOOLS_DIR/scripts/chobby-channel.sh"
+
+prompt_chobby_channel() {
+    local data_dir cfg current
+    data_dir="${BAR_DATA_DIR:-$(read_env_key BAR_DATA_DIR)}"
+    if [ -z "$data_dir" ]; then
+        warn "chobby_channel: BAR_DATA_DIR not set; defaulting to byar-dev (will apply once data dir is configured)."
+        write_env_key BAR_CHOBBY_CHANNEL "byar-dev"
+        return 0
+    fi
+    cfg="$data_dir/chobby_config.json"
+    current="$(_chobby_game_field "$cfg")"
+
+    info "Chobby's gameConfig channel decides whether your local checkout loads:"
+    info "  byar-dev  -> games/Beyond-All-Reason.sdd (your edits, dev mode on)"
+    info "  byar      -> latest rapid test build (read-only, dev mode off)"
+    [ -n "$current" ] && info "Current chobby_config.json: $current"
+
+    local def=y saved
+    saved="$(read_env_key BAR_CHOBBY_CHANNEL)"
+    [ -n "$saved" ] && [ "$saved" != "byar-dev" ] && def=n
+    if ask_yes_no "Switch Chobby to byar-dev?" "$def"; then
+        write_env_key BAR_CHOBBY_CHANNEL "byar-dev"
+    else
+        write_env_key BAR_CHOBBY_CHANNEL "${current:-byar}"
+        warn "Keeping '${current:-byar}' channel. Run 'just bar::dev-mode' to switch later."
+    fi
+}
+
+apply_chobby_channel() {
+    local data_dir desired current widget_current
+    data_dir="${BAR_DATA_DIR:-$(read_env_key BAR_DATA_DIR)}"
+    [ -n "$data_dir" ] || return 0
+    desired="$(read_env_key BAR_CHOBBY_CHANNEL)"
+    [ -n "$desired" ] || return 0
+
+    current="$(_chobby_game_field "$data_dir/chobby_config.json")"
+    widget_current="$(_chobby_widget_game_field "$data_dir")"
+    if [ "$current" = "$desired" ] && { [ -z "$widget_current" ] || [ "$widget_current" = "$desired" ]; }; then
+        return 0
+    fi
+    set_chobby_channel "$data_dir" "$desired"
+    ok "Chobby gameConfig set to $desired (chobby_config.json + IGL_data.lua)"
+}
+
+register_module chobby_channel BAR_CHOBBY_CHANNEL prompt_chobby_channel apply_chobby_channel config bar,chobby

--- a/scripts/setup/40-ssh.sh
+++ b/scripts/setup/40-ssh.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# shellcheck source=scripts/setup/_lib.sh
+# Module: ssh.
+
+prompt_ssh() { prompt_ssh_setup_choice; }
+apply_ssh()  { run_ssh_setup_choice; }
+
+summary_ssh() {
+    local v; v="$(read_env_key BAR_SSH_SETUP)"
+    case "$v" in
+        op)       echo "configure GitHub SSH via 1Password" ;;
+        manual)   echo "generate a GitHub SSH key, paste it to GitHub" ;;
+        existing) echo "use the SSH key already on this machine" ;;
+        skip)     echo "skip GitHub SSH setup" ;;
+        *)        echo "${v:-<unset>}" ;;
+    esac
+}
+
+register_module ssh BAR_SSH_SETUP prompt_ssh apply_ssh

--- a/scripts/setup/50-editor.sh
+++ b/scripts/setup/50-editor.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# shellcheck source=scripts/setup/_lib.sh
+# Module: editor.
+
+prompt_editor() { prompt_editor_setup_choice; }
+apply_editor()  { run_editor_setup_choice; }
+
+summary_editor() {
+    if [ "$(read_env_key BAR_EDITOR_SETUP)" = "yes" ]; then
+        echo "export emmylua/stylua/clangd to ~/.local/bin, write .vscode settings"
+    else
+        echo "no editor integration"
+    fi
+}
+
+# deferred: apply_editor runs distrobox-export, which needs the bar-dev
+# container that cmd_init only creates after the config phase.
+register_module editor BAR_EDITOR_SETUP prompt_editor apply_editor deferred bar,recoil

--- a/scripts/setup/60-springsettings.sh
+++ b/scripts/setup/60-springsettings.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# shellcheck source=scripts/setup/_lib.sh
+# Module: springsettings.
+
+prompt_springsettings() { prompt_springsettings_opt_in; }
+apply_springsettings()  { :; }
+
+summary_springsettings() {
+    if [ "$(read_env_key ALLOW_SPRINGSETTINGS_MOD)" = "1" ]; then
+        echo "bar::launch may modify the engine's springsettings.cfg"
+    else
+        echo "leave springsettings.cfg untouched"
+    fi
+}
+
+register_module springsettings ALLOW_SPRINGSETTINGS_MOD prompt_springsettings apply_springsettings config bar,recoil

--- a/scripts/setup/_lib.sh
+++ b/scripts/setup/_lib.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Module registry + lifecycle engine for setup::init.
+
+# Each entry: "name|env_key|prompt_fn|apply_fn|when|features"
+# when=config applies right after the prompt; when=deferred defers apply to
+# the end of cmd_init (after distrobox/clones/builds exist).
+declare -ag SETUP_MODULES=()
+declare -Ag SETUP_MODULE_INDEX=()  # name -> index in SETUP_MODULES
+
+register_module() {
+    local name="$1" key="$2" prompt_fn="$3" apply_fn="$4" when="${5:-config}" features="${6:-}"
+    local f
+    for f in "$prompt_fn" "$apply_fn"; do
+        if ! declare -F "$f" >/dev/null; then
+            echo "[register_module] $name: function '$f' not defined" >&2
+            return 1
+        fi
+    done
+    case "$when" in
+        config|deferred) ;;
+        *) echo "[register_module] $name: unknown when='$when' (config|deferred)" >&2; return 1 ;;
+    esac
+    SETUP_MODULE_INDEX["$name"]=${#SETUP_MODULES[@]}
+    SETUP_MODULES+=("$name|$key|$prompt_fn|$apply_fn|$when|$features")
+}
+
+# parse an entry into the SETUP_M_* vars in the caller's scope
+_load_module_entry() {
+    local entry="$1"
+    IFS='|' read -r SETUP_M_NAME SETUP_M_KEY SETUP_M_PROMPT SETUP_M_APPLY SETUP_M_WHEN SETUP_M_FEATURES <<<"$entry"
+    : "${SETUP_M_WHEN:=config}"
+}
+
+# true if $1 has no feature gate or one of its gate features is selected.
+# parses into locals so callers iterating SETUP_M_* aren't clobbered.
+module_relevant() {
+    local idx="${SETUP_MODULE_INDEX[$1]:-}"
+    if [ -z "$idx" ]; then
+        err "module_relevant: no module registered as '$1'"
+        return 1
+    fi
+    local _n _k _p _a _w _feats
+    IFS='|' read -r _n _k _p _a _w _feats <<<"${SETUP_MODULES[$idx]}"
+    [ -z "$_feats" ] && return 0
+    feature_selected "$_feats"
+}
+
+# drive a module through "read; prompt if empty or reset; apply".
+# apply only fires here for when=config; deferred modules apply later.
+ensure_module() {
+    _load_module_entry "$1"
+    local current
+    current="$(read_env_key "$SETUP_M_KEY")"
+    if [ -z "$current" ] || [ -n "${BAR_RESET_CONFIG:-}" ]; then
+        "$SETUP_M_PROMPT"
+    else
+        info "$SETUP_M_NAME: using $SETUP_M_KEY=$current from .env"
+        if [ -z "${_RECONFIG_HINT_SHOWN:-}" ]; then
+            info "  (re-run 'just setup::reconfigure' to change saved answers)"
+            _RECONFIG_HINT_SHOWN=1
+        fi
+    fi
+    if [ "$SETUP_M_WHEN" = "config" ]; then
+        "$SETUP_M_APPLY"
+    fi
+}
+
+# run apply for every when=deferred module
+apply_deferred_modules() {
+    local entry
+    for entry in "${SETUP_MODULES[@]}"; do
+        _load_module_entry "$entry"
+        [ "$SETUP_M_WHEN" = "deferred" ] || continue
+        module_relevant "$SETUP_M_NAME" || continue
+        step "deferred apply: $SETUP_M_NAME"
+        "$SETUP_M_APPLY"
+    done
+}
+
+# run a single module by name; used by `just <module>::setup` recipes
+ensure_module_by_name() {
+    local name="$1"
+    local idx="${SETUP_MODULE_INDEX[$name]:-}"
+    if [ -z "$idx" ]; then
+        err "ensure_module_by_name: no module registered as '$name'"
+        return 1
+    fi
+    ensure_module "${SETUP_MODULES[$idx]}"
+}
+
+# iterate every registered module through ensure_module
+ensure_all_modules() {
+    local n=${#SETUP_MODULES[@]} i=0 entry
+    for entry in "${SETUP_MODULES[@]}"; do
+        i=$((i+1))
+        _load_module_entry "$entry"
+        step "config $i/$n  $SETUP_M_NAME"
+        ensure_module "$entry"
+        echo ""
+    done
+}
+
+doctor_modules() {
+    local entry val
+    printf "  %-20s %-22s %s\n" "MODULE" "KEY" "VALUE"
+    printf "  %-20s %-22s %s\n" "------" "---" "-----"
+    for entry in "${SETUP_MODULES[@]}"; do
+        _load_module_entry "$entry"
+        val="$(read_env_key "$SETUP_M_KEY")"
+        if [ -n "$val" ]; then
+            printf "  %-20s %-22s %s\n" "$SETUP_M_NAME" "$SETUP_M_KEY" "$val"
+        else
+            printf "  %-20s %-22s ${DIM}<unset>${NC}\n" "$SETUP_M_NAME" "$SETUP_M_KEY"
+        fi
+    done
+}
+
+# one human line per module for confirm_setup_plan; a module may define an
+# optional summary_<name>, else the raw persisted value is shown
+summarize_modules() {
+    local entry fn val
+    for entry in "${SETUP_MODULES[@]}"; do
+        _load_module_entry "$entry"
+        module_relevant "$SETUP_M_NAME" || continue
+        fn="summary_${SETUP_M_NAME}"
+        if declare -F "$fn" >/dev/null; then
+            val="$("$fn")"
+        else
+            val="$(read_env_key "$SETUP_M_KEY")"
+            val="${val:-<unset>}"
+        fi
+        printf '    %-16s %s\n' "$SETUP_M_NAME" "$val"
+    done
+}
+
+# source numbered module files in filename order (underscored files skipped)
+_load_setup_modules() {
+    local dir="${BASH_SOURCE[0]%/*}"
+    local f
+    for f in "$dir"/[0-9]*.sh; do
+        [ -f "$f" ] || continue
+        # shellcheck disable=SC1090
+        source "$f"
+    done
+}

--- a/scripts/ssh/lib.sh
+++ b/scripts/ssh/lib.sh
@@ -7,19 +7,15 @@ is_wsl() {
     [ -n "${WSL_DISTRO_NAME:-}" ] || [ -f /proc/sys/fs/binfmt_misc/WSLInterop ]
 }
 
-# Sets OP_SSH_ENV to one of: wsl, bazzite, linux-arch, linux-debian, linux-fedora, unknown.
+# Sets OP_SSH_ENV to one of: wsl, fedora-atomic, linux-arch, linux-debian, linux-fedora, unknown.
 detect_env() {
     if is_wsl; then
         OP_SSH_ENV=wsl
         return
     fi
-    if [ -r /etc/os-release ]; then
-        # shellcheck disable=SC1091
-        . /etc/os-release
-        if [ "${VARIANT_ID:-}" = "bazzite" ] || [ "${ID:-}" = "bazzite" ]; then
-            OP_SSH_ENV=bazzite
-            return
-        fi
+    if [ -f /run/ostree-booted ] || have rpm-ostree; then
+        OP_SSH_ENV=fedora-atomic
+        return
     fi
     if have pacman; then OP_SSH_ENV=linux-arch
     elif have apt-get; then OP_SSH_ENV=linux-debian

--- a/scripts/ssh/lib.sh
+++ b/scripts/ssh/lib.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Shared helpers for scripts/ssh/*.sh. Source after scripts/common.sh.
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+is_wsl() {
+    [ -n "${WSL_DISTRO_NAME:-}" ] || [ -f /proc/sys/fs/binfmt_misc/WSLInterop ]
+}
+
+# Sets OP_SSH_ENV to one of: wsl, bazzite, linux-arch, linux-debian, linux-fedora, unknown.
+detect_env() {
+    if is_wsl; then
+        OP_SSH_ENV=wsl
+        return
+    fi
+    if [ -r /etc/os-release ]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        if [ "${VARIANT_ID:-}" = "bazzite" ] || [ "${ID:-}" = "bazzite" ]; then
+            OP_SSH_ENV=bazzite
+            return
+        fi
+    fi
+    if have pacman; then OP_SSH_ENV=linux-arch
+    elif have apt-get; then OP_SSH_ENV=linux-debian
+    elif have dnf; then OP_SSH_ENV=linux-fedora
+    else OP_SSH_ENV=unknown
+    fi
+}
+
+pause() {
+    step "$*"
+    read -rp "       Press Enter when done... " _
+}
+
+# True if 1Password's SSH agent is reachable and has keys loaded.
+op_ssh_already_active() {
+    local sock
+    for sock in "$HOME/.1password/agent.sock" "$HOME/.ssh/agent.sock"; do
+        [ -S "$sock" ] || continue
+        SSH_AUTH_SOCK="$sock" ssh-add -l >/dev/null 2>&1 && return 0
+    done
+    return 1
+}
+
+# Echo the path to the user's interactive shell rc file.
+shellrc_path() {
+    case "${SHELL:-}" in
+        *zsh) echo "$HOME/.zshrc" ;;
+        *)    echo "$HOME/.bashrc" ;;
+    esac
+}
+
+# shellrc_apply <marker> <content>
+# Idempotently install <content> in a marked block in the shell rc file.
+# Sets SHELLRC_TARGET to the path touched.
+shellrc_apply() {
+    local marker="$1"; shift
+    local content="$*"
+    local rc; rc="$(shellrc_path)"
+    SHELLRC_TARGET="$rc"
+    local begin="# >>> ${marker} >>>"
+    local end="# <<< ${marker} <<<"
+    local tmp; tmp="$(mktemp)"
+
+    touch "$rc"
+    if grep -qF "$begin" "$rc"; then
+        awk -v b="$begin" -v e="$end" -v body="$content" '
+            $0 == b { print; print body; in_block=1; next }
+            $0 == e { print; in_block=0; next }
+            !in_block { print }
+        ' "$rc" > "$tmp"
+    else
+        cat "$rc" > "$tmp"
+        {
+            echo ""
+            echo "$begin"
+            echo "$content"
+            echo "$end"
+        } >> "$tmp"
+    fi
+    mv "$tmp" "$rc"
+}
+
+# Verify the agent end-to-end. SSH_AUTH_SOCK must be set in the calling shell.
+op_ssh_verify() {
+    local listing rc
+    # ssh-add exits 1 = no keys, 2 = no agent; capture without tripping set -e.
+    if listing="$(ssh-add -l 2>&1)"; then rc=0; else rc=$?; fi
+
+    if [ $rc -eq 2 ]; then
+        err "Could not reach the SSH agent at \$SSH_AUTH_SOCK ($SSH_AUTH_SOCK)."
+        err "  Confirm 1Password Desktop is running and signed in, and that"
+        err "  Settings → Developer → 'Use the SSH agent' is enabled."
+        return 1
+    fi
+    if [ $rc -eq 1 ]; then
+        warn "Agent is reachable but no SSH keys are loaded."
+        warn "  Open 1Password and add an SSH key item (or unlock an existing"
+        warn "  one), then re-run 'just ssh::op-setup'. Without a loaded key"
+        warn "  the bridge succeeds silently and the first git operation"
+        warn "  fails with 'Permission denied (publickey)'."
+        return 1
+    fi
+
+    ok "Agent is live and ssh-add sees keys:"
+    printf '%s\n' "$listing" | sed 's/^/    /'
+    echo ""
+
+    step "    Probing github.com for end-to-end auth"
+    # github.com's SSH greeting always exits 1 (no shell); `|| true` keeps set -e calm.
+    local gh_out
+    gh_out="$(ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+                  -o ConnectTimeout=5 -T git@github.com 2>&1 || true)"
+    # Success signal is the "successfully authenticated" message, not the exit code.
+    if printf '%s' "$gh_out" | grep -q "successfully authenticated"; then
+        ok "github.com authenticated as $(printf '%s' "$gh_out" | sed -n 's/^Hi \([^!]*\)!.*/\1/p')."
+        op_ssh_pin_protocol_ssh
+    else
+        warn "github.com did not accept any loaded key:"
+        printf '%s\n' "$gh_out" | sed 's/^/    /'
+        warn "  The agent is bridged correctly, but the keys 1Password is"
+        warn "  exposing aren't registered on your GitHub account. Add one"
+        warn "  at https://github.com/settings/keys (the public key for any"
+        warn "  loaded item) and re-run."
+    fi
+}
+
+# Pin repos.local.conf to '@protocol ssh' once SSH is proven working.
+# Idempotent: skips if the user already set any @protocol directive.
+op_ssh_pin_protocol_ssh() {
+    local conf="${DEVTOOLS_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}/repos.local.conf"
+    if [ -f "$conf" ] && grep -qE '^[[:space:]]*@protocol[[:space:]]' "$conf"; then
+        info "repos.local.conf already pins @protocol — leaving it alone."
+        return 0
+    fi
+    {
+        [ -s "$conf" ] && echo ""
+        echo "# Auto-pinned by just ssh::op-setup after github.com auth succeeded."
+        echo "@protocol ssh"
+    } >> "$conf"
+    ok "Pinned @protocol ssh in $conf — clones/pushes will use the bridged agent."
+}
+
+# WSL-only. Echoes the Windows %USERPROFILE% as a WSL path.
+win_userprofile() {
+    local raw
+    # || true: handle missing cmd.exe interop via the empty-$raw branch below.
+    raw="$(cmd.exe /c 'echo %USERPROFILE%' 2>/dev/null | tr -d '\r\n')" || true
+    [ -n "$raw" ] || { err "could not read Windows %USERPROFILE%"; return 1; }
+    wslpath -u "$raw"
+}

--- a/scripts/ssh/setup-linux-ssh.sh
+++ b/scripts/ssh/setup-linux-ssh.sh
@@ -16,10 +16,10 @@ is_op_installed() {
 
 install_op_desktop() {
     case "$OP_SSH_ENV" in
-        bazzite)
-            info "Bazzite is rpm-ostree immutable — using Flatpak."
+        fedora-atomic)
+            info "Fedora Atomic (rpm-ostree) is immutable — using Flatpak."
             if ! have flatpak; then
-                err "flatpak not found on Bazzite (unexpected). Install it via rpm-ostree first."
+                err "flatpak not found (unexpected on Fedora Atomic). Install it via rpm-ostree first."
                 return 1
             fi
             flatpak install --user -y --noninteractive flathub com.onepassword.OnePassword
@@ -76,7 +76,7 @@ install_op_cli() {
         return
     fi
     case "$OP_SSH_ENV" in
-        bazzite)
+        fedora-atomic)
             # Flatpak desktop bundle doesn't include `op`.
             local arch url tmp
             arch="$(uname -m)"

--- a/scripts/ssh/setup-linux-ssh.sh
+++ b/scripts/ssh/setup-linux-ssh.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Native-Linux 1Password SSH agent + CLI bootstrap.
+set -euo pipefail
+
+DEVTOOLS_DIR="${DEVTOOLS_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+# shellcheck source=../common.sh
+source "$DEVTOOLS_DIR/scripts/common.sh"
+# shellcheck source=./lib.sh
+source "$DEVTOOLS_DIR/scripts/ssh/lib.sh"
+
+detect_env
+
+is_op_installed() {
+    have 1password || have onepassword || flatpak info com.onepassword.OnePassword >/dev/null 2>&1
+}
+
+install_op_desktop() {
+    case "$OP_SSH_ENV" in
+        bazzite)
+            info "Bazzite is rpm-ostree immutable — using Flatpak."
+            if ! have flatpak; then
+                err "flatpak not found on Bazzite (unexpected). Install it via rpm-ostree first."
+                return 1
+            fi
+            flatpak install --user -y --noninteractive flathub com.onepassword.OnePassword
+            ;;
+        linux-arch)
+            if have paru; then
+                paru -S --noconfirm 1password 1password-cli
+            elif have yay; then
+                yay -S --noconfirm 1password 1password-cli
+            else
+                warn "No AUR helper (paru/yay). Install 1Password from AUR manually."
+                pause "Install '1password' and '1password-cli' from the AUR"
+            fi
+            ;;
+        linux-debian)
+            info "Adding 1Password apt repository..."
+            curl -sS https://downloads.1password.com/linux/keys/1password.asc \
+                | sudo gpg --dearmor --yes -o /usr/share/keyrings/1password-archive-keyring.gpg
+            echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/amd64 stable main' \
+                | sudo tee /etc/apt/sources.list.d/1password.list >/dev/null
+            sudo mkdir -p /etc/debsig/policies/AC2D62742012EA22/
+            curl -sS https://downloads.1password.com/linux/debian/debsig/1password.pol \
+                | sudo tee /etc/debsig/policies/AC2D62742012EA22/1password.pol >/dev/null
+            sudo mkdir -p /usr/share/debsig/keyrings/AC2D62742012EA22
+            curl -sS https://downloads.1password.com/linux/keys/1password.asc \
+                | sudo gpg --dearmor --yes -o /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg
+            sudo apt-get update
+            sudo apt-get install -y 1password 1password-cli
+            ;;
+        linux-fedora)
+            info "Adding 1Password dnf repository..."
+            sudo rpm --import https://downloads.1password.com/linux/keys/1password.asc
+            sudo sh -c 'cat > /etc/yum.repos.d/1password.repo <<EOF
+[1password]
+name=1Password Stable Channel
+baseurl=https://downloads.1password.com/linux/rpm/stable/\$basearch
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://downloads.1password.com/linux/keys/1password.asc
+EOF'
+            sudo dnf install -y 1password 1password-cli
+            ;;
+        *)
+            err "Unsupported environment: $OP_SSH_ENV"
+            return 1
+            ;;
+    esac
+}
+
+install_op_cli() {
+    if have op; then
+        ok "op CLI already installed ($(op --version))"
+        return
+    fi
+    case "$OP_SSH_ENV" in
+        bazzite)
+            # Flatpak desktop bundle doesn't include `op`.
+            local arch url tmp
+            arch="$(uname -m)"
+            case "$arch" in
+                x86_64) arch=amd64 ;;
+                aarch64) arch=arm64 ;;
+                *) err "unsupported arch for op CLI: $arch"; return 1 ;;
+            esac
+            tmp="$(mktemp -d)"
+            url="https://cache.agilebits.com/dist/1P/op2/pkg/v2/op_linux_${arch}_latest.zip"
+            info "Downloading op CLI from $url"
+            curl -fsSL -o "$tmp/op.zip" "$url"
+            (cd "$tmp" && unzip -o op.zip >/dev/null)
+            mkdir -p "$HOME/.local/bin"
+            install -m 0755 "$tmp/op" "$HOME/.local/bin/op"
+            rm -rf "$tmp"
+            ok "Installed op to ~/.local/bin/op"
+            ;;
+        linux-arch|linux-debian|linux-fedora)
+            warn "op should have been installed alongside the desktop. Re-run install if missing."
+            ;;
+    esac
+}
+
+step "1/5 Install 1Password Desktop"
+if is_op_installed; then
+    ok "1Password Desktop already installed."
+else
+    install_op_desktop
+fi
+
+step "2/5 Install 1Password CLI"
+install_op_cli
+
+step "3/5 Enable SSH agent + CLI integration"
+if op_ssh_already_active; then
+    ok "1Password SSH agent already serving keys -- skipping toggle prompt."
+else
+    cat <<EOF
+       In 1Password Desktop:
+         Settings → Developer
+           [x] Use the SSH agent
+           [x] Integrate with 1Password CLI
+         Settings → Security
+           Lock after the system is idle for: 4 hours
+       (BAR's first-time download/build is long enough that the default
+        15 minutes will re-lock the vault mid-setup and break SSH ops.)
+       Then sign in to your account if you haven't already.
+EOF
+    pause "Toggle both Developer checkboxes and bump idle-lock to 4 hours"
+fi
+
+SHELL_RC="$(shellrc_path)"
+step "4/5 Append SSH_AUTH_SOCK to ${SHELL_RC/#$HOME/~}"
+read -r -d '' SHELLRC_BODY <<'BLOCK' || true
+if [ -S "$HOME/.1password/agent.sock" ]; then
+    export SSH_AUTH_SOCK="$HOME/.1password/agent.sock"
+fi
+BLOCK
+shellrc_apply "1password-ssh-agent" "$SHELLRC_BODY"
+ok "Updated ${SHELLRC_TARGET/#$HOME/~} (block: 1password-ssh-agent)"
+
+step "5/5 Test the agent"
+SOCK="$HOME/.1password/agent.sock"
+if [ ! -S "$SOCK" ]; then
+    warn "$SOCK does not exist yet."
+    warn "1Password may still be starting; or the SSH agent toggle isn't enabled."
+    exit 0
+fi
+SSH_AUTH_SOCK="$SOCK" op_ssh_verify
+echo ""
+info "Open a new shell to pick up the ${SHELLRC_TARGET/#$HOME/~} snippet automatically."

--- a/scripts/ssh/setup-manual-ssh.sh
+++ b/scripts/ssh/setup-manual-ssh.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Manual SSH setup: generate a key, run a plain ssh-agent, register the public
+# key on GitHub, and verify. Fallback for contributors without a password manager.
+set -euo pipefail
+
+DEVTOOLS_DIR="${DEVTOOLS_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+# shellcheck source=../common.sh
+source "$DEVTOOLS_DIR/scripts/common.sh"
+# shellcheck source=./lib.sh
+source "$DEVTOOLS_DIR/scripts/ssh/lib.sh"
+
+KEY_PATH="$HOME/.ssh/id_ed25519"
+KEY_TYPE="ed25519"
+
+step "1/4 SSH key"
+mkdir -p "$HOME/.ssh"
+chmod 700 "$HOME/.ssh"
+if [ -f "$KEY_PATH" ]; then
+    info "Existing key at $KEY_PATH — keeping it."
+else
+    info "Generating a new $KEY_TYPE key at $KEY_PATH."
+    info "  You can leave the passphrase blank for unattended use, but a"
+    info "  passphrase + ssh-agent caching is the recommended posture."
+    ssh-keygen -t "$KEY_TYPE" -C "$(whoami)@$(hostname) (BAR-Devtools)" -f "$KEY_PATH"
+    ok "Key generated."
+fi
+
+step "2/4 ssh-agent"
+if ! ssh-add -l >/dev/null 2>&1; then
+    if [ -z "${SSH_AUTH_SOCK:-}" ]; then
+        info "No ssh-agent in this shell — starting one."
+        eval "$(ssh-agent -s)" >/dev/null
+    fi
+fi
+if ! ssh-add -L 2>/dev/null | grep -qF "$(ssh-keygen -y -f "$KEY_PATH")"; then
+    info "Adding $KEY_PATH to the agent (you'll be prompted if it has a passphrase)."
+    ssh-add "$KEY_PATH"
+fi
+
+shellrc_apply "manual-ssh-agent" "$(cat <<BLOCK
+# Start a user ssh-agent on first interactive shell and reuse it across shells.
+SSH_ENV="\$HOME/.ssh/agent-env"
+if [ ! -S "\${SSH_AUTH_SOCK:-}" ]; then
+    if [ -f "\$SSH_ENV" ]; then
+        # shellcheck disable=SC1090
+        . "\$SSH_ENV" >/dev/null
+    fi
+    if ! ssh-add -l >/dev/null 2>&1; then
+        ssh-agent -s > "\$SSH_ENV"
+        chmod 600 "\$SSH_ENV"
+        # shellcheck disable=SC1090
+        . "\$SSH_ENV" >/dev/null
+        ssh-add "$KEY_PATH" 2>/dev/null || true
+    fi
+fi
+export SSH_AUTH_SOCK SSH_AGENT_PID
+BLOCK
+)"
+ok "Updated ${SHELLRC_TARGET/#$HOME/~} (block: manual-ssh-agent)."
+
+step "3/4 Register the public key on GitHub"
+echo ""
+echo "    Open this page in a browser (logged in as the GitHub account you'll"
+echo "    contribute from):"
+echo ""
+echo "        https://github.com/settings/ssh/new"
+echo ""
+echo "    Title:  $(hostname) (BAR-Devtools)"
+echo "    Type:   Authentication Key"
+echo "    Key:"
+echo ""
+sed 's/^/        /' "${KEY_PATH}.pub"
+echo ""
+read -rp "    Press Enter once you've added the key... " _
+
+step "4/4 Verify"
+op_ssh_verify
+echo ""
+info "Open a new shell to pick up the ${SHELLRC_TARGET/#$HOME/~} snippet automatically."

--- a/scripts/ssh/setup-op-ssh.sh
+++ b/scripts/ssh/setup-op-ssh.sh
@@ -34,11 +34,11 @@ case "$OP_SSH_ENV" in
     wsl)
         exec bash "$DEVTOOLS_DIR/scripts/ssh/setup-wsl-ssh.sh" "$@"
         ;;
-    bazzite|linux-arch|linux-debian|linux-fedora)
+    fedora-atomic|linux-arch|linux-debian|linux-fedora)
         exec bash "$DEVTOOLS_DIR/scripts/ssh/setup-linux-ssh.sh" "$@"
         ;;
     *)
-        err "Unsupported environment. This wizard supports WSL2 and native Linux (Bazzite/Arch/Debian/Fedora)."
+        err "Unsupported environment. This wizard supports WSL2 and native Linux (Fedora Atomic/Arch/Debian/Fedora)."
         exit 1
         ;;
 esac

--- a/scripts/ssh/setup-op-ssh.sh
+++ b/scripts/ssh/setup-op-ssh.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# 1Password SSH agent + CLI bootstrap; dispatches to the WSL or native-Linux wizard.
+set -euo pipefail
+
+DEVTOOLS_DIR="${DEVTOOLS_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+# shellcheck source=../common.sh
+source "$DEVTOOLS_DIR/scripts/common.sh"
+# shellcheck source=./lib.sh
+source "$DEVTOOLS_DIR/scripts/ssh/lib.sh"
+
+detect_env
+
+cat <<EOF
+${BOLD}1Password SSH agent setup${NC}
+
+Detected environment: ${BOLD}${OP_SSH_ENV}${NC}
+
+This wizard will:
+  1. Install 1Password Desktop (and CLI) where it's missing.
+  2. Pause while you enable "Use the SSH agent" + "Integrate with 1Password CLI"
+     in 1Password's settings — those toggles are GUI-only.
+  3. On WSL: install socat + npiperelay.exe and bridge the Windows agent.
+     On native Linux: point SSH_AUTH_SOCK at ~/.1password/agent.sock.
+  4. Append an idempotent block to your shell rc (~/.zshrc if $SHELL is zsh,
+     otherwise ~/.bashrc) so the agent is wired on every shell.
+  5. Test with ssh-add -l.
+
+Re-running is safe: every step checks before acting, and the rc block is
+replaced in place rather than duplicated.
+
+EOF
+
+case "$OP_SSH_ENV" in
+    wsl)
+        exec bash "$DEVTOOLS_DIR/scripts/ssh/setup-wsl-ssh.sh" "$@"
+        ;;
+    bazzite|linux-arch|linux-debian|linux-fedora)
+        exec bash "$DEVTOOLS_DIR/scripts/ssh/setup-linux-ssh.sh" "$@"
+        ;;
+    *)
+        err "Unsupported environment. This wizard supports WSL2 and native Linux (Bazzite/Arch/Debian/Fedora)."
+        exit 1
+        ;;
+esac

--- a/scripts/ssh/setup-wsl-ssh.sh
+++ b/scripts/ssh/setup-wsl-ssh.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# WSL <-> Windows 1Password SSH agent bridge.
+# Chain: $SSH_AUTH_SOCK -> socat (WSL) -> npiperelay.exe -> 1Password's named pipe.
+set -euo pipefail
+
+DEVTOOLS_DIR="${DEVTOOLS_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+# shellcheck source=../common.sh
+source "$DEVTOOLS_DIR/scripts/common.sh"
+# shellcheck source=./lib.sh
+source "$DEVTOOLS_DIR/scripts/ssh/lib.sh"
+
+is_wsl || { err "setup-wsl-ssh.sh must run inside WSL."; exit 1; }
+
+NPIPERELAY_URL="https://github.com/jstarks/npiperelay/releases/latest/download/npiperelay_windows_amd64.zip"
+
+winget_install() {
+    local id="$1" name="$2"
+    if ! have powershell.exe; then
+        warn "powershell.exe not on PATH — cannot drive winget. Install $name manually."
+        return 1
+    fi
+    info "Checking winget for $name ($id)..."
+    if powershell.exe -NoProfile -Command "winget list --id $id -e" >/dev/null 2>&1; then
+        ok "$name already installed (winget reports it present)."
+        return 0
+    fi
+    info "Installing $name via winget..."
+    powershell.exe -NoProfile -Command \
+        "winget install --id $id -e --accept-source-agreements --accept-package-agreements --silent" \
+        || { warn "winget install of $name failed."; return 1; }
+    ok "$name installed."
+}
+
+step "1/7 Install 1Password Desktop on Windows"
+if ! winget_install "AgileBits.1Password" "1Password Desktop"; then
+    pause "Download and install 1Password from https://1password.com/downloads/windows/"
+fi
+
+step "2/7 Install 1Password CLI on Windows"
+if ! winget_install "AgileBits.1Password.CLI" "1Password CLI"; then
+    pause "Download and install the 1Password CLI from https://developer.1password.com/docs/cli/get-started/"
+fi
+
+step "3/7 Enable SSH agent + CLI integration"
+if op_ssh_already_active; then
+    ok "1Password SSH agent already serving keys -- skipping toggle prompt."
+else
+    cat <<EOF
+       In 1Password Desktop:
+         Settings → Developer
+           [x] Use the SSH agent
+           [x] Integrate with 1Password CLI
+         Settings → Security
+           Lock after the system is idle for: 4 hours
+       (BAR's first-time download/build is long enough that the default
+        15 minutes will re-lock the vault mid-setup and break SSH ops.)
+       Then sign in to your account if you haven't already.
+EOF
+    pause "Toggle both Developer checkboxes and bump idle-lock to 4 hours"
+fi
+
+step "4/7 Install socat in WSL"
+if have socat; then
+    ok "socat already installed."
+else
+    info "Running: sudo apt-get update && sudo apt-get install -y socat"
+    sudo apt-get update
+    sudo apt-get install -y socat
+fi
+
+step "5/7 Install npiperelay.exe on the Windows side"
+WIN_HOME="$(win_userprofile)"
+NPR_DIR="${WIN_HOME}/AppData/Local/npiperelay"
+NPR_EXE="${NPR_DIR}/npiperelay.exe"
+mkdir -p "$NPR_DIR"
+if [ -x "$NPR_EXE" ]; then
+    ok "npiperelay.exe already at $NPR_EXE"
+else
+    info "Downloading npiperelay..."
+    tmp="$(mktemp -d)"
+    curl -fL --progress-bar -o "$tmp/npr.zip" "$NPIPERELAY_URL"
+    if ! have unzip; then
+        info "unzip missing; installing..."
+        sudo apt-get install -y unzip
+    fi
+    unzip -o "$tmp/npr.zip" -d "$NPR_DIR" >/dev/null
+    rm -rf "$tmp"
+    [ -x "$NPR_EXE" ] || { err "extraction did not produce $NPR_EXE"; exit 1; }
+    ok "Installed $NPR_EXE"
+fi
+mkdir -p "$HOME/.local/bin"
+ln -sf "$NPR_EXE" "$HOME/.local/bin/npiperelay.exe"
+
+SHELL_RC="$(shellrc_path)"
+step "6/7 Append bridge snippet to ${SHELL_RC/#$HOME/~}"
+read -r -d '' SHELLRC_BODY <<'BLOCK' || true
+export SSH_AUTH_SOCK="$HOME/.ssh/agent.sock"
+if ! ss -xl 2>/dev/null | grep -q "$SSH_AUTH_SOCK"; then
+    rm -f "$SSH_AUTH_SOCK"
+    (setsid socat UNIX-LISTEN:"$SSH_AUTH_SOCK",fork \
+        EXEC:"npiperelay.exe -ei -s //./pipe/openssh-ssh-agent",nofork \
+        >/dev/null 2>&1 &)
+fi
+BLOCK
+shellrc_apply "1password-ssh-agent" "$SHELLRC_BODY"
+ok "Updated ${SHELLRC_TARGET/#$HOME/~} (block: 1password-ssh-agent)"
+
+step "7/7 Test the bridge"
+export SSH_AUTH_SOCK="$HOME/.ssh/agent.sock"
+rm -f "$SSH_AUTH_SOCK"
+PATH="$HOME/.local/bin:$PATH" setsid socat UNIX-LISTEN:"$SSH_AUTH_SOCK",fork \
+    EXEC:"npiperelay.exe -ei -s //./pipe/openssh-ssh-agent",nofork \
+    >/dev/null 2>&1 &
+sleep 1
+op_ssh_verify
+echo ""
+info "Open a new shell to pick up the bashrc snippet automatically."

--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -1,0 +1,436 @@
+"""WSL-side sync daemon: mirrors Devtools checkout subtrees through /mnt/c
+into the Windows NTFS data dir via watchman. Runs inside the bar-sync
+container; invoked by scripts/sync.sh. Plan 9 doesn't forward inotify, so
+the watcher must run WSL-side, not Windows-side.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Iterable
+
+try:
+    import pywatchman
+except ImportError as exc:
+    sys.stderr.write(
+        "pywatchman not installed. This script is meant to run inside the\n"
+        "bar-sync distrobox container -- see docker/sync.Containerfile.\n"
+        "If you're invoking it directly, build the container with:\n"
+        "    just setup::distrobox\n"
+    )
+    raise SystemExit(1) from exc
+
+
+log = logging.getLogger("bar-launch.sync")
+
+
+# .git pack files are read-only on disk -> Errno 13 storms on re-copy.
+_SKIP_DIRS = frozenset({".git", ".github", "__pycache__", "node_modules"})
+
+
+def _is_skipped(rel: Path) -> bool:
+    return any(part in _SKIP_DIRS for part in rel.parts)
+
+
+def _state_dir() -> Path:
+    """Persistent state dir; must stay on ext4, not /mnt/c."""
+    base = os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local" / "state")
+    d = Path(base) / "bar-devtools"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _pair_state_path(src_root: Path, dst_root: Path) -> Path:
+    h = hashlib.sha1(f"{src_root}::{dst_root}".encode()).hexdigest()[:12]
+    return _state_dir() / f"sync-state-{h}.json"
+
+
+def _load_pair_state(path: Path) -> dict:
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def _save_pair_state(path: Path, src_root: Path, dst_root: Path,
+                     clock: str) -> None:
+    payload = json.dumps({
+        "src": str(src_root),
+        "dst": str(dst_root),
+        "clock": clock,
+    }, indent=2)
+    tmp = path.with_suffix(f".tmp.{os.getpid()}")
+    with open(tmp, "w") as f:
+        f.write(payload)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, path)
+
+
+def _decode(v):
+    # pywatchman BSER returns bytes for string values.
+    if isinstance(v, bytes):
+        return v.decode("utf-8", errors="replace")
+    return v
+
+
+def _apply_files(src_root: Path, dst_root: Path,
+                 files: list[dict], event_ts: float) -> None:
+    """Mirror a watchman batch into dst_root. --inplace is load-bearing:
+    spring mmaps Lua sources, so a tempfile-and-rename invalidates the mmap.
+    """
+    changed: list[str] = []
+    deleted_names: list[str] = []
+    for f in files:
+        name = _decode(f["name"])
+        rel = Path(name)
+        if _is_skipped(rel):
+            continue
+        if f.get("exists", True):
+            changed.append(name)
+        else:
+            deleted_names.append(name)
+
+    copied = 0
+    if changed:
+        try:
+            subprocess.run(
+                ["rsync", "-a", "--inplace", "--files-from=-",
+                 f"{src_root}/", f"{dst_root}/"],
+                input="\n".join(changed) + "\n",
+                text=True,
+                check=True,
+            )
+            copied = len(changed)
+        except FileNotFoundError as exc:
+            log.error("rsync not found on PATH inside container: %s", exc)
+        except subprocess.CalledProcessError as exc:
+            # exit 23: some files not transferred -- usually Windows holding
+            # dst files open. Survivable; the next save retries.
+            if exc.returncode == 23:
+                log.warning(
+                    "rsync exit 23 for %s -> %s (some files not transferred). "
+                    "Most common cause: Windows holds open handles on the "
+                    "destination. Stop spring.exe / BAR launcher (just bar::stop) "
+                    "and re-trigger.", src_root, dst_root)
+            else:
+                log.warning("rsync exit %d for %s -> %s -- batch may be partial",
+                            exc.returncode, src_root, dst_root)
+            copied = 0
+
+    deleted = 0
+    for name in deleted_names:
+        target = dst_root / name
+        try:
+            target.unlink()
+            deleted += 1
+        except FileNotFoundError:
+            pass
+        except IsADirectoryError:
+            try:
+                target.rmdir()
+                deleted += 1
+            except OSError:
+                pass
+        except OSError as exc:
+            log.warning(
+                "could not delete dst %s (Windows may hold an open "
+                "handle; next save will overwrite): %s", target, exc)
+
+    if copied or deleted:
+        latency_ms = (time.monotonic() - event_ts) * 1000.0
+        # Show paths for small batches; big batches collapse to a count.
+        sample = changed + [f"-{n}" for n in deleted_names]
+        if len(sample) <= 5:
+            detail = ": " + ", ".join(sample)
+        else:
+            detail = ""
+        log.info("mirrored %d, deleted %d (%dms) [%s]%s",
+                 copied, deleted, round(latency_ms), src_root.name, detail)
+
+
+def _watch_root(client: "pywatchman.client", src_root: Path) -> tuple[str, str | None]:
+    resp = client.query("watch-project", str(src_root))
+    return _decode(resp["watch"]), _decode(resp.get("relative_path"))
+
+
+def _build_subscribe_query(relative_path: str | None,
+                           since_clock: str | None) -> dict:
+    q: dict = {"fields": ["name", "exists"]}
+    if relative_path:
+        q["relative_root"] = relative_path
+    if since_clock:
+        q["since"] = since_clock
+    return q
+
+
+def _drain_pair(src_root: Path, dst_root: Path,
+                stop: threading.Event,
+                cold_only: bool,
+                ready_signal: threading.Event | None) -> None:
+    """One pair's subscription loop; reconnects on socket close."""
+    state_path = _pair_state_path(src_root, dst_root)
+    state = _load_pair_state(state_path)
+    same_pair = (state.get("src") == str(src_root)
+                 and state.get("dst") == str(dst_root))
+    saved_clock = state.get("clock") if same_pair else None
+
+    sub_name = f"bar-sync-{os.getpid()}-{src_root.name}"
+
+    while not stop.is_set():
+        try:
+            client = pywatchman.client(timeout=60.0)
+            try:
+                watch_root, relative_path = _watch_root(client, src_root)
+                query = _build_subscribe_query(relative_path, saved_clock)
+                client.query("subscribe", watch_root, sub_name, query)
+                if saved_clock:
+                    log.info("subscription opened: %s (since clock=%s)",
+                             src_root, saved_clock[-12:])
+                else:
+                    log.info("subscription opened: %s (no prior clock -- initial seed)",
+                             src_root)
+
+                # Short timeout so stop-signal checks fan out without spinning.
+                client.setTimeout(2.0)
+                while not stop.is_set():
+                    try:
+                        msg = client.receive()
+                    except pywatchman.SocketTimeout:
+                        continue
+                    if not isinstance(msg, dict):
+                        continue
+                    if "subscription" not in msg:
+                        continue
+
+                    files = list(msg.get("files") or [])
+                    new_clock = _decode(msg.get("clock"))
+                    is_fresh = bool(msg.get("is_fresh_instance"))
+
+                    # Coalesce follow-on events from one logical save
+                    # (save-then-autoformat etc.); cap at 200ms.
+                    if not is_fresh and not cold_only:
+                        client.setTimeout(0.05)
+                        deadline = time.monotonic() + 0.20
+                        while not stop.is_set() and time.monotonic() < deadline:
+                            try:
+                                extra = client.receive()
+                            except pywatchman.SocketTimeout:
+                                break
+                            if not isinstance(extra, dict) \
+                               or "subscription" not in extra:
+                                continue
+                            files.extend(extra.get("files") or [])
+                            ec = _decode(extra.get("clock"))
+                            if ec:
+                                new_clock = ec
+                            if extra.get("is_fresh_instance"):
+                                is_fresh = True
+                        client.setTimeout(2.0)
+
+                    if is_fresh:
+                        log.info(
+                            "is_fresh_instance: %s (%d files) -- %s",
+                            src_root, len(files),
+                            "watchman has no prior clock for this subscription"
+                            if not saved_clock else
+                            "watchman daemon was restarted; saved clock invalid")
+
+                    if files:
+                        # Dedupe by name; last write wins on the exists flag.
+                        latest: dict[str, dict] = {}
+                        for f in files:
+                            n = _decode(f.get("name"))
+                            if n is None:
+                                continue
+                            latest[n] = f
+                        _apply_files(src_root, dst_root,
+                                     list(latest.values()),
+                                     time.monotonic())
+
+                    if new_clock:
+                        saved_clock = new_clock
+                        _save_pair_state(state_path, src_root, dst_root,
+                                         new_clock)
+
+                    if ready_signal is not None and not ready_signal.is_set():
+                        ready_signal.set()
+
+                    if cold_only:
+                        return
+            finally:
+                try:
+                    client.close()
+                except Exception:
+                    pass
+        except (pywatchman.WatchmanError, OSError) as exc:
+            if stop.is_set():
+                return
+            log.warning("watchman socket error for %s: %s -- reconnecting in 2s",
+                        src_root, exc)
+            stop.wait(2.0)
+
+
+def _parse_pairs(pairs: Iterable[str]) -> list[tuple[Path, Path]]:
+    parsed: list[tuple[Path, Path]] = []
+    for raw in pairs:
+        sep = raw.find("::")
+        if sep < 0:
+            raise SystemExit(f"--pair must be SRC::DST, got: {raw!r}")
+        src = Path(raw[:sep])
+        dst = Path(raw[sep + 2 :])
+        if not src.exists():
+            log.warning("source missing (will retry on event): %s", src)
+        parsed.append((src, dst))
+    return parsed
+
+
+def _setup_logging(log_path: Path | None) -> None:
+    # With --log, only the FileHandler: sync.sh already redirects stderr to
+    # the log, so a StreamHandler would double every line.
+    handlers: list[logging.Handler] = []
+    if log_path is not None:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        handlers.append(logging.FileHandler(str(log_path), encoding="utf-8"))
+    else:
+        handlers.append(logging.StreamHandler(sys.stderr))
+    logging.basicConfig(
+        level=os.environ.get("BAR_SYNC_LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        handlers=handlers,
+        force=True,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="bar-launch-sync",
+        description="Mirror WSL Devtools checkouts to a Windows NTFS data dir via watchman.",
+    )
+    parser.add_argument(
+        "--pair",
+        action="append",
+        required=True,
+        metavar="SRC::DST",
+        help="Source (WSL ext4 path) and destination (POSIX form of /mnt/c/...), "
+             "separated by '::'. Repeatable.",
+    )
+    parser.add_argument("--log", type=Path,
+                        help="Append log lines to this file in addition to stderr.")
+    parser.add_argument(
+        "--cold-copy",
+        action="store_true",
+        help="Run a one-shot mirror of each pair (process the first "
+             "subscription batch and exit). No watching.",
+    )
+    parser.add_argument(
+        "--ready-file",
+        type=Path,
+        help="After every pair has processed its first batch, touch this file. "
+        "Used by scripts/sync.sh to gate `bar-launch` invocation on a quiesced "
+        "initial mirror.",
+    )
+    args = parser.parse_args(argv)
+
+    _setup_logging(args.log)
+
+    pairs = _parse_pairs(args.pair)
+    log.info("sync: %d pair(s)", len(pairs))
+
+    stop = threading.Event()
+
+    _SIGNAL_REASONS = {
+        signal.SIGINT:  "SIGINT (Ctrl-C in the foreground terminal)",
+        signal.SIGTERM: "SIGTERM (likely 'just bar::stop' or 'sync.sh stop')",
+        signal.SIGHUP:  "SIGHUP (controlling terminal closed)",
+    }
+
+    def _on_signal(signum, _frame):
+        reason = _SIGNAL_REASONS.get(signum, f"signal {signum}")
+        log.info("received %s -- closing subscriptions and exiting", reason)
+        stop.set()
+
+    signal.signal(signal.SIGINT, _on_signal)
+    signal.signal(signal.SIGTERM, _on_signal)
+    try:
+        signal.signal(signal.SIGHUP, _on_signal)
+    except (AttributeError, ValueError):
+        pass
+
+    # One thread per pair so a slow rsync on one tree doesn't block another.
+    ready_events: list[threading.Event] = []
+    threads: list[threading.Thread] = []
+    for src, dst in pairs:
+        if not src.exists():
+            log.warning("skipping pair: %s does not exist", src)
+            continue
+        dst.mkdir(parents=True, exist_ok=True)
+        ev = threading.Event()
+        ready_events.append(ev)
+        t = threading.Thread(
+            target=_drain_pair,
+            args=(src.resolve(), dst.resolve(), stop, args.cold_copy, ev),
+            name=f"sync-{src.name}",
+            daemon=True,
+        )
+        t.start()
+        threads.append(t)
+
+    if not threads:
+        log.error("no pairs to mirror; exiting")
+        return 1
+
+    # Surface inotify limit at startup -- low limits silently drop events.
+    try:
+        with open("/proc/sys/fs/inotify/max_user_watches") as f:
+            limit = int(f.read().strip())
+        log.info("watcher up; %d pair(s) (fs.inotify.max_user_watches=%d)",
+                 len(threads), limit)
+        if limit < 131072:
+            log.warning(
+                "fs.inotify.max_user_watches=%d is low for BAR-sized trees; "
+                "events for deep subtrees may not fire. Bump persistently:\n"
+                "  echo 'fs.inotify.max_user_watches=524288' | sudo tee /etc/sysctl.d/99-bar-devtools.conf\n"
+                "  sudo sysctl -p /etc/sysctl.d/99-bar-devtools.conf", limit)
+    except OSError:
+        log.info("watcher up; %d pair(s) scheduled", len(threads))
+
+    # Wait for every pair's first batch, then signal ready.
+    if args.ready_file is not None or args.cold_copy:
+        for ev in ready_events:
+            while not ev.wait(timeout=0.5):
+                # Don't hang forever if a thread died before signalling.
+                if all(not t.is_alive() for t in threads):
+                    log.error("all sync threads exited before signalling ready")
+                    return 1
+                if stop.is_set():
+                    return 0
+        if args.ready_file is not None:
+            args.ready_file.parent.mkdir(parents=True, exist_ok=True)
+            args.ready_file.touch()
+
+    if args.cold_copy:
+        for t in threads:
+            t.join(timeout=10)
+        return 0
+
+    while not stop.is_set():
+        stop.wait(0.5)
+
+    for t in threads:
+        t.join(timeout=5)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -1,0 +1,343 @@
+#!/usr/bin/env bash
+# WSL host entry point for the mirror daemon. Enters the bar-sync container
+# to run scripts/sync.py.
+#
+# Subcommands: start [--wait-ready] | stop | status | cold-copy
+#              | mirror-engine | logs [-f|...]
+
+set -euo pipefail
+
+: "${DEVTOOLS_DIR:?DEVTOOLS_DIR must be set (Justfile exports it)}"
+source "$DEVTOOLS_DIR/scripts/common.sh"
+
+require_host
+
+if [ -z "${BAR_DATA_DIR:-}" ]; then
+  err "BAR_DATA_DIR not set. Run 'just setup::init' on WSL2 first."
+  exit 1
+fi
+
+if ! grep -qi microsoft /proc/version 2>/dev/null; then
+  err "scripts/sync.sh only runs on WSL2 (target is a Windows-side data dir)."
+  exit 1
+fi
+
+# Capture the listing first: `grep -q` would SIGPIPE `distrobox list` under
+# pipefail, flipping a match into a failure.
+_require_sync_distrobox() {
+  local listing
+  listing="$(distrobox list 2>/dev/null || true)"
+  if ! printf '%s\n' "$listing" | grep -F "| ${DEVTOOLS_SYNC_DISTROBOX} " >/dev/null 2>&1; then
+    err "sync container '${DEVTOOLS_SYNC_DISTROBOX}' does not exist."
+    info "Build it: just setup::distrobox  (creates bar-dev + bar-sync on WSL)"
+    return 1
+  fi
+}
+
+STATE_DIR="$BAR_DATA_DIR/.bar-launch"
+LOG_FILE="$STATE_DIR/sync.log"
+PID_FILE="$STATE_DIR/sync.pid"
+READY_FILE="$STATE_DIR/sync.ready"
+mkdir -p "$STATE_DIR"
+
+# Destinations need a `.sdd` suffix: spring only scans unpacked-dir archives
+# whose name ends in .sdd.
+_compute_source_pairs() {
+  local pairs=()
+  local missing=()
+  local bar_src="$DEVTOOLS_DIR/Beyond-All-Reason"
+  local chobby_src="$DEVTOOLS_DIR/BYAR-Chobby"
+  local bar_dst="$BAR_DATA_DIR/games/Beyond-All-Reason.sdd"
+  local chobby_dst="$BAR_DATA_DIR/games/BYAR-Chobby.sdd"
+
+  # Never-linked = silent skip; broken symlink = error.
+  _classify_pair() {
+    local name="$1" src="$2" dst="$3"
+    if [ -L "$src" ] && [ ! -e "$src" ]; then
+      missing+=("$name (broken symlink: $src -> $(readlink "$src"))")
+    elif [ -d "$src" ]; then
+      pairs+=("$(readlink -f "$src")::$dst")
+    fi
+  }
+  _classify_pair "Beyond-All-Reason" "$bar_src"    "$bar_dst"
+  _classify_pair "BYAR-Chobby"       "$chobby_src" "$chobby_dst"
+  unset -f _classify_pair
+
+  if [ "${#missing[@]}" -gt 0 ]; then
+    err "sync source(s) configured but not resolvable:"
+    local m
+    for m in "${missing[@]}"; do err "  - $m"; done
+    err "Recreate the link(s):"
+    err "  just link::create bar       # for Beyond-All-Reason"
+    err "  just link::create chobby    # for BYAR-Chobby"
+    err "Or re-run 'just setup::init' to refresh repos.local.conf."
+    return 1
+  fi
+
+  if [ "${#pairs[@]}" -eq 0 ]; then
+    err "No sync sources found. Clone Beyond-All-Reason / BYAR-Chobby"
+    err "(just repos::clone bar / chobby) and link them with"
+    err "(just link::create bar / chobby)."
+    return 1
+  fi
+
+  printf '%s\n' "${pairs[@]}"
+}
+
+# Engine pair is mirrored on demand (from `just engine::build`), never watched.
+_compute_engine_pair() {
+  local engine_src="$DEVTOOLS_DIR/RecoilEngine/build-amd64-windows/install"
+  local engine_dst="$BAR_DATA_DIR/engine/local-build"
+  if [ ! -d "$engine_src" ]; then
+    return 1
+  fi
+  echo "$(readlink -f "$engine_src")::$engine_dst"
+}
+
+_pid_alive() {
+  local pid="$1"
+  [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null
+}
+
+_running_pid() {
+  [ -f "$PID_FILE" ] || return 1
+  local pid
+  pid="$(cat "$PID_FILE" 2>/dev/null || true)"
+  if _pid_alive "$pid"; then
+    echo "$pid"
+    return 0
+  fi
+  return 1
+}
+
+cmd_status() {
+  local pid
+  if pid="$(_running_pid)"; then
+    info "sync daemon running, PID $pid (log: $LOG_FILE)"
+    return 0
+  fi
+  info "sync daemon not running"
+  return 1
+}
+
+cmd_start() {
+  local wait_ready=0
+  if [ "${1:-}" = "--wait-ready" ]; then
+    wait_ready=1
+    shift
+  fi
+
+  # Validate pairs before the already-running check so a stale daemon can't
+  # mask broken-symlink errors.
+  local pair_lines
+  if ! pair_lines="$(_compute_source_pairs)"; then
+    return 1
+  fi
+
+  local existing_pid
+  if existing_pid="$(_running_pid)"; then
+    # Restart if a running daemon's --pair args drifted from current config.
+    local cmdline live_pairs expected_pairs
+    cmdline="$(tr '\0' ' ' < /proc/"$existing_pid"/cmdline 2>/dev/null)"
+    live_pairs="$(echo "$cmdline" | awk 'BEGIN{RS=" "} /::/{print}' | sort -u)"
+    expected_pairs="$(echo "$pair_lines" | sort -u)"
+
+    if [ "$live_pairs" != "$expected_pairs" ]; then
+      warn "sync daemon (PID $existing_pid) was started with a different set of pairs than the current config:"
+      warn "  live pairs:"
+      while IFS= read -r line; do [ -n "$line" ] && warn "    $line"; done <<<"$live_pairs"
+      warn "  expected pairs (per current symlinks / repos.conf):"
+      while IFS= read -r line; do [ -n "$line" ] && warn "    $line"; done <<<"$expected_pairs"
+      err "Edits to paths in the expected list will NOT propagate -- the running daemon doesn't watch them."
+      err "Restart to pick up the new config:"
+      err "  bash $DEVTOOLS_DIR/scripts/sync.sh stop"
+      err "  bash $DEVTOOLS_DIR/scripts/sync.sh start --wait-ready"
+      return 1
+    fi
+
+    if [ -f "$READY_FILE" ]; then
+      info "sync daemon already running and ready (PID $existing_pid)"
+    else
+      warn "sync daemon running (PID $existing_pid) but ready-flag missing"
+      info "  (likely an orphan from a prior version; continuing without re-verify)"
+      info "  to refresh: bash $DEVTOOLS_DIR/scripts/sync.sh stop && ... start --wait-ready"
+    fi
+    return 0
+  fi
+
+  _require_sync_distrobox || return 1
+
+  local pair_args=()
+  local p
+  while IFS= read -r p; do
+    [ -n "$p" ] && pair_args+=(--pair "$p")
+  done <<<"$pair_lines"
+
+  rm -f "$READY_FILE"
+
+  step "Starting sync daemon (cold-copy + watcher) inside ${DEVTOOLS_SYNC_DISTROBOX}"
+  info "log: $LOG_FILE  (live: just bar::sync-logs)"
+  : >"$LOG_FILE"
+  # Saved PID is the host-side `distrobox enter` shim; it forwards SIGTERM
+  # to the in-container python3.
+  nohup distrobox enter "${DEVTOOLS_SYNC_DISTROBOX}" -- \
+      python3 "$DEVTOOLS_DIR/scripts/sync.py" \
+      --log "$LOG_FILE" \
+      --ready-file "$READY_FILE" \
+      "${pair_args[@]}" \
+      </dev/null >>"$LOG_FILE" 2>&1 &
+  local pid=$!
+  disown "$pid" 2>/dev/null || true
+  echo "$pid" > "$PID_FILE"
+  ok "sync daemon started, PID $pid"
+
+  if [ "$wait_ready" = "1" ]; then
+    _wait_for_ready "$pid"
+  fi
+}
+
+# Wait up to 300s for sync.py to touch READY_FILE; cold-copy can take 60-180s.
+_wait_for_ready() {
+  local pid="${1:-}"
+  if [ -z "$pid" ]; then pid="$(cat "$PID_FILE" 2>/dev/null || true)"; fi
+
+  info "waiting for cold copy to finish (this can be 30-180s on first run)..."
+  # tail -F: follows the recreate/truncate cmd_start did just before us.
+  tail -F -n 0 "$LOG_FILE" >&2 &
+  local tail_pid=$!
+  disown "$tail_pid" 2>/dev/null || true
+
+  local deadline=$((SECONDS + 300))
+  local rc=0
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if [ -f "$READY_FILE" ]; then
+      kill "$tail_pid" 2>/dev/null || true
+      ok "sync daemon ready (cold-copy + watcher up)"
+      return 0
+    fi
+    if [ -n "$pid" ] && ! _pid_alive "$pid"; then
+      kill "$tail_pid" 2>/dev/null || true
+      err "sync daemon exited before signalling ready (see $LOG_FILE)"
+      return 1
+    fi
+    sleep 0.25
+  done
+  kill "$tail_pid" 2>/dev/null || true
+  err "sync daemon did not signal ready within 300s (see $LOG_FILE)"
+  return 1
+}
+
+cmd_stop() {
+  local pid
+  if ! pid="$(_running_pid)"; then
+    info "sync daemon not running"
+    rm -f "$PID_FILE"
+    return 0
+  fi
+  step "Stopping sync daemon (PID $pid)"
+  kill -TERM "$pid" 2>/dev/null || true
+  # Up to 5s for sync.py's signal handler to drain pending events.
+  local i=0
+  while [ $i -lt 50 ]; do
+    if ! _pid_alive "$pid"; then
+      break
+    fi
+    sleep 0.1
+    i=$((i + 1))
+  done
+  if _pid_alive "$pid"; then
+    warn "sync daemon did not exit on SIGTERM; sending SIGKILL"
+    kill -KILL "$pid" 2>/dev/null || true
+  fi
+  rm -f "$PID_FILE" "$READY_FILE"
+  ok "sync daemon stopped"
+}
+
+# One-shot seed of the source pairs; pre-warms Watchman state so the next
+# cmd_start goes straight to the incremental path.
+cmd_cold_copy() {
+  local pair_lines
+  if ! pair_lines="$(_compute_source_pairs)"; then
+    return 1
+  fi
+
+  _require_sync_distrobox || return 1
+
+  local pair_args=()
+  local p
+  while IFS= read -r p; do
+    [ -n "$p" ] && pair_args+=(--pair "$p")
+  done <<<"$pair_lines"
+
+  step "Cold-copy seed (one-shot, no watcher) inside ${DEVTOOLS_SYNC_DISTROBOX}"
+  info "log: $LOG_FILE  (live: just bar::sync-logs)"
+  : >"$LOG_FILE"
+
+  tail -F -n 0 "$LOG_FILE" >&2 &
+  local tail_pid=$!
+  disown "$tail_pid" 2>/dev/null || true
+
+  local rc=0
+  distrobox enter "${DEVTOOLS_SYNC_DISTROBOX}" -- \
+      python3 "$DEVTOOLS_DIR/scripts/sync.py" \
+      --log "$LOG_FILE" \
+      --cold-copy \
+      "${pair_args[@]}" \
+      </dev/null >>"$LOG_FILE" 2>&1 || rc=$?
+
+  kill "$tail_pid" 2>/dev/null || true
+  if [ $rc -eq 0 ]; then
+    ok "Cold-copy seed complete -- next bar::launch will be incremental."
+  else
+    err "Cold-copy seed failed (rc=$rc). See $LOG_FILE."
+    err "First 'just bar::launch' will fall back to a full rsync seed."
+  fi
+  return $rc
+}
+
+cmd_mirror_engine() {
+  local engine_pair
+  if ! engine_pair="$(_compute_engine_pair)"; then
+    warn "no engine build at $DEVTOOLS_DIR/RecoilEngine/build-amd64-windows/install -- skipping mirror"
+    return 0
+  fi
+
+  # A live spring.exe share-locks the engine DLLs; rsync would EACCES and
+  # leave a half-mirrored install.
+  local holders
+  if ! holders="$(_engine_holders)"; then
+    err "Cannot mirror engine -- the following process(es) are running and hold the engine binaries:"
+    while IFS= read -r h; do err "  - $h"; done <<<"$holders"
+    err "Stop them first, then re-run 'just engine::build windows' (or just 'sync.sh mirror-engine'):"
+    err "  just bar::stop"
+    return 1
+  fi
+
+  _require_sync_distrobox || return 1
+  step "Mirroring engine artifacts to $BAR_DATA_DIR/engine/local-build (via ${DEVTOOLS_SYNC_DISTROBOX})"
+  distrobox enter "${DEVTOOLS_SYNC_DISTROBOX}" -- \
+      python3 "$DEVTOOLS_DIR/scripts/sync.py" --cold-copy --log "$LOG_FILE" --pair "$engine_pair"
+  ok "engine mirrored"
+}
+
+cmd_logs() {
+  if [ ! -f "$LOG_FILE" ]; then
+    info "no log yet at $LOG_FILE"
+    return 0
+  fi
+  exec tail "$@" "$LOG_FILE"
+}
+
+case "${1:-status}" in
+  start)         shift; cmd_start "$@" ;;
+  stop)          shift; cmd_stop  "$@" ;;
+  status)        shift; cmd_status "$@" ;;
+  cold-copy)     shift; cmd_cold_copy "$@" ;;
+  mirror-engine) shift; cmd_mirror_engine "$@" ;;
+  logs)          shift; cmd_logs "$@" ;;
+  *)
+    err "Unknown subcommand: $1"
+    echo "Usage: scripts/sync.sh {start [--wait-ready]|stop|status|cold-copy|mirror-engine|logs}" >&2
+    exit 2
+    ;;
+esac

--- a/templates/bar-vscode-settings.json
+++ b/templates/bar-vscode-settings.json
@@ -1,0 +1,11 @@
+{
+  "files.exclude": {
+    "**/.devtools": false,
+    "**/.devtools/**": false,
+    "**/.lux": false,
+    "**/.lux/**": false
+  },
+  "[lua]": {
+    "editor.defaultFormatter": "JohnnyMorganz.stylua"
+  }
+}

--- a/templates/recoil-vscode-settings.json
+++ b/templates/recoil-vscode-settings.json
@@ -1,0 +1,3 @@
+{
+  "clangd.path": "__HOME__/.local/bin/clangd"
+}


### PR DESCRIPTION
 ## What's it do

  This PR threads three bodies of work together: launcher polish, a real WSL2 sync daemon, and an SSH setup           namespace so new contributors don't land on HTTPS by accident. Common spine: every interactive decision moves up
  front, and there's exactly one way to do each thing.

  ### 1. `bar::launch` polish

  - **Auto engine selection.** `launch.sh` injects `--engine local-build` when `engine/local-build` exists and the
  user didn't already set `--engine`. Logs the resolved `bar-launch` invocation before `exec`-ing so you can see
  exactly what's about to run.
  - **AppImage path discovery.** New `ensure_bar_appimage_path_set` step in `setup.sh`: scans `~/Applications`,
  prompts if not found, persists `BAR_APPIMAGE_PATH` to `.env`. Accepts a file or a directory so an upgrade-in-place
   AppImage doesn't need a `.env` edit.
  - **`bar::log` recipe.** `tail -F` on the engine's `infolog.txt` so contributors don't have to hunt for the data
  dir. Skips capturing `launch.sh`'s own output -- the engine already writes `infolog.txt` and `bar-launch` exits
  immediately after spawn.
  - **Comment update.** `bar::launch` recipe now points at `--headless` / `--no-gui` for the headless flow.

  ### 2. WSL2 sync daemon

  Architecture `wsl-watchdog-mntc`, picked from a probe sweep of six candidates -- see
  `bar-design-docs/bifurcated_types/dev_setup_restructured.md`.

  - **`sync.py`.** `watchdog` Observer + worker thread on the WSL side, writes to `/mnt/c` with `rsync --inplace`.
  The `--inplace` matters: the engine mmaps Lua sources, and a tempfile+rename would flip the inode under the mmap.
  - **Cold copy via Watchman.** "What changed since clock T" queries skip the ~80s rsync stat-walk on `/mnt/c`.
  Mandatory, no host fallback -- if Watchman isn't on PATH the daemon fails loud.
  - **`sync.sh` lifecycle.** `start [--wait-ready] / stop / status / mirror-engine / logs`. Validates pair list
  before "already running" early-return so a missing source symlink can't stay silent. Drift-detects when the pair
  list changes between invocations.
  - **`bar::stop` kills the engine processes.** `spring.exe` / `Beyond-All-Reason.exe` / `python.exe` via `taskkill
  /F /T /PID` + verify, so `engine::build`'s rsync doesn't hit drvfs `EACCES` on locked DLLs.

  ### 3. `--debug-gl` is sticky-aware

  - **`_MANAGED_SPRINGSETTINGS` whitelist** in `launch.sh`: launching with the flag sets the keys, launching without
   it resets them. Only the flags listed in that table are touched.
  - **Opt-in.** Gated by `ALLOW_SPRINGSETTINGS_MOD` in `.env` (set at `setup::init`).

  ### 4. Distrobox is the toolchain habitat

  - **`setup::init` unconditionally rebuilds.** Idempotent: `stop --yes; rm --yes; create` against the current
  Containerfile.
  - **`dev.Containerfile` pinned to `fedora:42`** to match Meta's Watchman RPM ABI (boost 1.83, libglog.so.0).
  Watchman, `emmylua_ls`, `stylua`, `lux`, `clangd` all live in the container; `setup.sh` exposes them on host PATH
  via `distrobox-export`.
  - **One way only.** No host-side install path. No `--no-distrobox` flag. Audit pass removed `cmd_once`,
  `_have_watchman`, the existence-check-before-recreate ceremony, and the `BAR_SETUP_CONSENT` flag (running the
  script is the consent).

  ### 5. `setup::init` flow

  - **Step 0 front-loads every interactive decision:** BAR sync dir, feature selection, symlink y/N, springsettings
  opt-in, SSH setup choice. Steps 1-7 then roll unattended.

  ### 6. SSH setup namespace (`just ssh::*`)

  HTTPS is a real footgun for new contributors -- token-prompt-prone, no push-by-default, and trivial to silently
  fall back to when SSH would have just worked. Letting people land on it costs them an evening before they figure
  out it's the protocol, not their network.

  - **`just ssh::op-setup`** -- 1Password Desktop + agent bridge for WSL2 or native Linux
  (Bazzite/Arch/Debian/Fedora). On WSL bridges `\\.\pipe\openssh-ssh-agent` via `npiperelay` + `socat`; on native
  Linux points `SSH_AUTH_SOCK` at `~/.1password/agent.sock`.
  - **`just ssh::manual-setup`** -- universal fallback. Generates `~/.ssh/id_ed25519`, starts `ssh-agent`, installs
  a persistent agent-bootstrap block in `~/.bashrc`, prints the pubkey + the `github.com/settings/ssh/new` URL with
  title/type/key fields filled in, waits for Enter, then runs the same end-to-end probe.
  - **Shared diagnostic `op_ssh_verify`** (`scripts/ssh/lib.sh`): three-tier check that distinguishes "agent
  unreachable" / "agent up but no keys loaded" / "keys present but github.com rejects them," each with the exact
  recovery step. On end-to-end success it auto-pins `@protocol ssh` in `repos.local.conf` so future `just
  repos::clone` runs use SSH (idempotent: skips if any `@protocol` directive is already set).
  - **`just ssh::doctor`** -- read-only health check; uses `op_ssh_verify` so the diagnostic shape matches setup
  time.
  - **Bitwarden / KeePassXC** are not yet wired up. When someone wants either, they write the real script + recipe
  in one PR; no placeholders.

  ### 7. `repos.local.conf` field-level overrides

  `scripts/repos.sh` parser changed from whole-row replace to per-field merge. Only the `directory` column is
  required; `url` / `branch` / `feature` / `local_path` inherit from `repos.conf` when blank. Forking one repo is
  now a one-column line:

      bar_debug_launcher   git@github.com:me/bar_debug_launcher.git

  -- branch and features come from `repos.conf` without restating.

  ### 8. `.claude/skills/`

  Five skills capturing the architecture, naming convention, container trust rules, prompt-front-loading pattern,
  and the "exactly one way" audit rule. Future contributors hit these before re-litigating decisions the probe data
  already settled.

### 9. Folded-in: editor-setup-emmylua (closes the standalone editor PR)                                              
  The four editor commits originally targeted as their own PR now ride on top of the launch work. Same scope as the
  editor PR's summary, retained verbatim:

  - `setup::editor` wiring for emmylua (replaces LuaLS in `bar::check`)
  - VS Code extension install + `templates/bar-vscode-settings.json` workspace template
  - ramped-up anti-sumneko prompt
  - drops force-formatOnSave from the BAR workspace template — `formatOnSave` rejoins the template in the bar-fmt PR

  Plus changes that only make sense in the combined PR:

  - `setup::editor` prompts (install missing extensions / uninstall sumneko) are now front-loaded above the binary
  export + cmake step. Per the front-load-prompts skill: long-running setup recipes batch interactive decisions up
  front so a contributor can answer once and walk away.
  - `scripts/bootstrap.sh` + `_check_just_min_version` in `cmd_init`. Ubuntu LTS ships `just` 1.21 (frozen), which
  silently mis-parses our module syntax and `[confirm("…")]`. The bootstrap script is an idempotent wrapper around
  `https://just.systems/install.sh`; `cmd_init` rejects a stale `just` before the long-running steps start, with a
  pointer back to the bootstrap script. README quickstart is now `clone → bash scripts/bootstrap.sh → just
  setup::init`.
  - `setup::init` now runs `setup::editor` automatically, front loading the question of whether the user wants to do it along with all the others and previewing changes

  #### Test plan (delta from the original editor PR)

  - [x] On a clean WSL2 with `apt install just` (1.21), `just setup::init` exits immediately with a `bootstrap.sh`
  pointer rather than failing mid-build
  - [x] `bash scripts/bootstrap.sh` is idempotent — second run no-ops
  - [x] `setup::editor` asks both prompts before any export/cmake work; non-interactive stdin defaults to "no"

####  Format-on-save remains intentionally off; same rationale as the original PR description.

### 10. Upstream and Origin Remotes
I hit a problem during a fresh clone with Recoil builds failing because they were missing tags from upstream (I started with my fork). I think the answer to this problem is to _always_ map `repos.conf` -> `upstream` remote and fetch tags, and `repos.local.conf` -> `origin`. This allows us to always have upstream mapped.

Added a `just repos::fixup` to attempt to remedy this situation without making everyone re-clone or fix their own remotes on an already cloned repo. Had to make it opt-in because I didn't want to ninja edit during sync.

  ## LLMs

  Yes

  ## Required work

  - https://github.com/beyond-all-reason/bar_debug_launcher/pull/13 (for the launch branch)
  - https://github.com/beyond-all-reason/RecoilEngine/pull/2961