### PR TITLE
add doctor check for using the old repos.local.conf format

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -129,6 +129,25 @@ check_doctor_repos() {
     return
   fi
 
+  if [ -f "$REPOS_LOCAL" ]; then
+      local old_local_conf_entries
+      old_local_conf_entries="$(
+        awk '
+          /^[[:space:]]*($|#|@)/ { next }
+          $4 == "core" || $4 == "extra" { print $1 " (" $4 ")" }
+        ' "$REPOS_LOCAL"
+      )"
+
+      if [ -n "$old_local_conf_entries" ]; then
+        _warn "repos.local.conf appears to use the old group format (core/extra)"
+        echo "$old_local_conf_entries" | sed 's/^/       /'
+        echo ""
+        echo "       Delete repos.local.conf to use repos.conf defaults,"
+        echo "       or recreate it using the current repos.conf format."
+        echo ""
+      fi
+    fi
+
   local i missing_features_set=""
   local -a missing=()
   for i in "${!REPO_DIRS[@]}"; do


### PR DESCRIPTION
### what it does
Warns the user if they are using an old `repos.local.conf` format and recommends they delete or replace the file with a newer format

### why
- Having an `repos.local.conf` that was using the previous groupings (e.g "core", "extra", not the new "teiserver" format) seems to have been the cause of https://github.com/beyond-all-reason/BAR-Devtools/issues/35 


### testing / risk level

- Manually tested this doctor output and it performed as expected.
- Since doctor is read only and just makes observations and recommendations, this should be very low impact


### before 
(no warning)

### after
```
[warn]  repos.local.conf appears to use the old group format (core/extra)
       teiserver (core)
       bar-lobby (core)
       spads_config_bar (core)
       ansible-spads-setup (extra)
       BYAR-Chobby (extra)
       bar-db (extra)
       bar-live-services (extra)
       SPADS (extra)
       SpringLobbyInterface (extra)

       Delete repos.local.conf to use repos.conf defaults,
       or recreate it using the current repos.conf format.

```

### LLM Disclosure
I used DeepSeek v4 Pro to generate this code

