### PR TITLE
adds `just tei mix` and `just tei dev-shell` tools for convenience

### DIFF
--- a/just/tei.just
+++ b/just/tei.just
@@ -21,7 +21,7 @@ setup-test-db: require-setup
     {{COMPOSE}} run --rm -e MIX_ENV=test --entrypoint "" \
         teiserver bash -c "mix ecto.create --quiet 2>/dev/null; mix ecto.migrate --quiet"
 
-# Run teiserver mix tests (optional path for a single file)
+# Run teiserver mix tests (arguments optional)
 test *args: require-setup
     #!/usr/bin/env bash
     set -euo pipefail
@@ -30,6 +30,28 @@ test *args: require-setup
     {{COMPOSE}} run --rm -e MIX_ENV=test --entrypoint "" \
         -v {{TEISERVER_DIR}}/test:/app/test:z \
         teiserver mix test {{args}}
+
+
+# Run teiserver mix in dev mode (expects a mix task to be provided, arguments optional)
+mix *args: require-setup
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    require_host
+    {{COMPOSE}} run --rm --service-ports -e MIX_ENV=dev --entrypoint "" \
+        -v {{TEISERVER_DIR}}/:/app/:z \
+        teiserver mix {{args}}
+
+
+# Drop into an interactive dev shell for teiserver
+dev-shell: require-setup
+    #!/usr/bin/env bash
+    set -euo pipefail
+    source "$DEVTOOLS_DIR/scripts/common.sh"
+    require_host
+    {{COMPOSE}} run --rm --service-ports -e MIX_ENV=dev --entrypoint "" \
+        -v {{TEISERVER_DIR}}/:/app/:z \
+        teiserver bash -c "echo 'Entering teiserver dev shell (MIX_ENV=dev). Type exit to return.' && exec bash"
 
 # Drop into an interactive test shell for teiserver
 test-shell: require-setup

--- a/just/tei.just
+++ b/just/tei.just
@@ -39,7 +39,6 @@ mix *args: require-setup
     source "$DEVTOOLS_DIR/scripts/common.sh"
     require_host
     {{COMPOSE}} run --rm --service-ports -e MIX_ENV=dev --entrypoint "" \
-        -v {{TEISERVER_DIR}}/:/app/:z \
         teiserver mix {{args}}
 
 
@@ -50,7 +49,6 @@ dev-shell: require-setup
     source "$DEVTOOLS_DIR/scripts/common.sh"
     require_host
     {{COMPOSE}} run --rm --service-ports -e MIX_ENV=dev --entrypoint "" \
-        -v {{TEISERVER_DIR}}/:/app/:z \
         teiserver bash -c "echo 'Entering teiserver dev shell (MIX_ENV=dev). Type exit to return.' && exec bash"
 
 # Drop into an interactive test shell for teiserver


### PR DESCRIPTION
- enables direct use of mix commands for linting, e.g. 
  - `just tei mix dialyzer --list-unused-filters`
  - `just tei mix credo --strict`
  - `just tei mix format`

- enables dev shell
- Allows bringing up the server with `mix phx.server` or `dev-shell` followed by `iex -S mix phx.server` and the server will be available at `localhost:4000` 