### PR TITLE
wsl fixes

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -38,7 +38,9 @@ read_env_key() {
 # append a newline when $1 has content but no trailing newline
 _ensure_trailing_newline() {
     local file="$1"
-    [ -s "$file" ] && [ -n "$(tail -c1 "$file")" ] && printf '\n' >> "$file"
+    if [ -s "$file" ] && [ -n "$(tail -c1 "$file")" ]; then
+        printf '\n' >> "$file"
+    fi
 }
 
 # upsert $1=$2 into .env

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -388,18 +388,20 @@ cmd_install_deps() {
     info "Missing (via package manager): ${apt_missing[*]}"
     info "Running: ${install_cmd}${packages}"
     echo ""
-    $install_cmd $packages
+    # set -e is off here (LHS of `||`); fresh-WSL apt lists are stale, so refresh and hard-fail explicitly.
+    [ "$distro" = "debian" ] && { sudo apt-get update || { err "apt-get update failed"; return 1; } ; }
+    $install_cmd $packages || { err "Package install failed: ${apt_missing[*]}"; return 1; }
     echo ""
   fi
 
   if [ "$distro" = "debian" ]; then
-    install_distrobox_upstream
+    install_distrobox_upstream || return 1
     echo ""
   fi
-  install_compose_upstream
+  install_compose_upstream || return 1
   echo ""
 
-  ensure_podman_socket
+  ensure_podman_socket || return 1
   echo ""
 
   ok "Dependencies installed successfully."


### PR DESCRIPTION
Whelp looks like my last few changes trying to ensure fail fast made it fail REALLY fast in WSL.

* scripts/common.sh:_ensure_trailing_newline returned exit status 1 in its normal no-op case (file already
  ends in a newline). It's the last statement in write_env_key's 'append a new key' branch, so write_env_key itself returned
  1. Under the recipe's set -euo pipefail, the first brand-new key appended to a newline-terminated .env aborts setup.

* Podman was also failing to install under wsl for ubuntu 24 because the default image was stale.