### PR TITLE
Drop teiserver .dockerignore injection; it now ships upstream

### DIFF
--- a/docker/teiserver.dockerignore
+++ b/docker/teiserver.dockerignore
@@ -1,9 +1,0 @@
-.git
-_build
-deps
-node_modules
-.elixir_ls
-.lexical
-.formatter_exs_cache
-cover
-doc

--- a/just/services.just
+++ b/just/services.just
@@ -11,8 +11,6 @@ up *args:
     set -euo pipefail
     source "$DEVTOOLS_DIR/scripts/common.sh"
     require_host
-    source "$DEVTOOLS_DIR/scripts/setup.sh"
-    install_dockerignore
 
     start_lobby=0
     with_spads=0
@@ -163,8 +161,6 @@ build:
     set -euo pipefail
     source "$DEVTOOLS_DIR/scripts/common.sh"
     require_host
-    source "$DEVTOOLS_DIR/scripts/setup.sh"
-    install_dockerignore
     info "Building Docker images..."
     info "  - Teiserver: compiling Elixir deps + generating TLS certs"
     info "  - SPADS: pulling pre-built image (badosu/spads:latest)"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -146,15 +146,6 @@ check_prerequisites() {
   fi
 }
 
-install_dockerignore() {
-  local target="$DEVTOOLS_DIR/teiserver/.dockerignore"
-  local source="$DEVTOOLS_DIR/docker/teiserver.dockerignore"
-  if [ -f "$source" ] && [ ! -f "$target" ]; then
-    cp "$source" "$target"
-    info "Installed .dockerignore for teiserver build context"
-  fi
-}
-
 # WSL2: enable systemd, mark / as a shared mount (needed for podman distrobox). No-op elsewhere.
 ensure_wsl_setup() {
   grep -qi microsoft /proc/version 2>/dev/null || return 0
@@ -1772,7 +1763,6 @@ cmd_init() {
   step "4/8  Building Docker images"
   echo ""
   if feature_selected teiserver; then
-    install_dockerignore
     info "Building Docker images..."
     $COMPOSE build teiserver
     $COMPOSE --profile spads pull spads
@@ -1953,7 +1943,6 @@ cmd_setup() {
     echo ""
   fi
 
-  install_dockerignore
   info "Building Docker images..."
   $COMPOSE build teiserver
   $COMPOSE --profile spads pull spads


### PR DESCRIPTION
Merge after: https://github.com/beyond-all-reason/teiserver/pull/1283

Dirties the working tree with an untracked file, which seems inaccurate.