### PR TITLE
detect flatpak setup and warn if symlinks outside

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -108,43 +108,73 @@ check_doctor_flatpak() {
     return
   fi
 
-  # Flatpak is installed and BAR is installed via it
   local ver
   ver="$(flatpak --version 2>/dev/null || echo "unknown")"
   _pass "$ver, info.beyondallreason.bar installed"
 
-  # Flatpak data dir where symlinks would sit
+  # Flatpak data dir where devtools symlinks would sit
   local flatpak_data_dir="$HOME/.var/app/info.beyondallreason.bar/data"
   [ -d "$flatpak_data_dir" ] || {
     echo ""
     return
   }
 
-  # Check each devtools symlink for flatpak exposure
+  # Collect permitted filesystem paths from Flatpak permissions (merged).
+  # Extract the line: filesystems=path:flag;path;path:ro;...
+  # then split on semicolons and strip trailing access-mode flags (:create, :ro, etc).
+  local -a permitted=("$flatpak_data_dir")
+  local perms_line
+  perms_line="$(flatpak info --show-permissions info.beyondallreason.bar 2>/dev/null | sed -n 's/^filesystems=//p')"
+  if [ -n "$perms_line" ]; then
+    local IFS=';'
+    local -a entries=($perms_line)
+    local e stripped
+    for e in "${entries[@]}"; do
+      [ -z "$e" ] && continue
+      # Strip access-mode flag after trailing colon
+      stripped="${e%:*}"
+      # Resolve tilde for ~/ paths and store as-is for absolute paths
+      case "$stripped" in
+        "~"/*) stripped="$HOME/${stripped#~/}" ;;
+        "~")   stripped="$HOME" ;;
+      esac
+      permitted+=("$stripped")
+    done
+  fi
+
+  # Check each devtools symlink: is its target inside a permitted path?
   local linked_outside=0
   local -A link_map=(
     [bar]="$flatpak_data_dir/games/Beyond-All-Reason.sdd"
     [chobby]="$flatpak_data_dir/games/BYAR-Chobby.sdd"
     [engine]="$flatpak_data_dir/engine/local-build"
   )
-  local name link_path target
+  local name link_path target perm
   for name in bar chobby engine; do
     link_path="${link_map[$name]}"
-    if [ -L "$link_path" ]; then
-      target="$(readlink "$link_path")"
+    [ -L "$link_path" ] || continue
+
+    target="$(readlink "$link_path")"
+
+    # No warning needed if the symlink target is in a flatpak-permitted path
+    local covered=0
+    for perm in "${permitted[@]}"; do
       case "$target" in
-        "$flatpak_data_dir"/*|"$HOME/.var/app/info.beyondallreason.bar"/*)
-          : ;;
-        *)
-          if [ "$linked_outside" -eq 0 ]; then
-            _warn "$name symlink target is outside Flatpak sandbox"
-            info "  $link_path -> $target"
-            linked_outside=1
-          else
-            info "  $name -> $target (also outside)"
-          fi
+        "$perm"/*|"$perm")
+          covered=1
+          break
           ;;
       esac
+    done
+
+    [ "$covered" -eq 1 ] && continue
+
+    if [ "$linked_outside" -eq 0 ]; then
+      _warn "$name symlink target is outside Flatpak sandbox"
+      info "  $link_path -> $target"
+      linked_outside=1
+    else
+      info "  $name -> $target (also outside)"
     fi
   done
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -108,9 +108,10 @@ check_doctor_flatpak() {
     return
   fi
 
-  local ver
+  local ver install_mode
   ver="$(flatpak --version 2>/dev/null || echo "unknown")"
-  _pass "$ver, info.beyondallreason.bar installed"
+  install_mode="$(flatpak info info.beyondallreason.bar 2>/dev/null | sed -n 's/^Installation: //p')"
+  _pass "$ver, info.beyondallreason.bar installed ($install_mode)"
 
   # Flatpak data dir where devtools symlinks would sit
   local flatpak_data_dir="$HOME/.var/app/info.beyondallreason.bar/data"
@@ -183,7 +184,11 @@ check_doctor_flatpak() {
     warn "The Flatpak sandbox blocks the Spring engine from following symlinks"
     warn "into folders it hasn't been granted access to."
     warn "Please grant access to these folders with:"
-    warn "  flatpak override --user info.beyondallreason.bar --filesystem=$DEVTOOLS_DIR"
+    if [ "$install_mode" = "system" ]; then
+      warn "  sudo flatpak override info.beyondallreason.bar --filesystem=$DEVTOOLS_DIR"
+    else
+      warn "  flatpak override --user info.beyondallreason.bar --filesystem=$DEVTOOLS_DIR"
+    fi
   fi
 
   echo ""

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -95,6 +95,71 @@ check_doctor_wsl() {
 }
 
 
+check_doctor_flatpak() {
+  if ! command -v flatpak &>/dev/null; then
+    _pass "flatpak not installed"
+    echo ""
+    return
+  fi
+
+  if ! flatpak info info.beyondallreason.bar &>/dev/null; then
+    _pass "flatpak installed, BAR not installed via flatpak"
+    echo ""
+    return
+  fi
+
+  # Flatpak is installed and BAR is installed via it
+  local ver
+  ver="$(flatpak --version 2>/dev/null || echo "unknown")"
+  _pass "$ver, info.beyondallreason.bar installed"
+
+  # Flatpak data dir where symlinks would sit
+  local flatpak_data_dir="$HOME/.var/app/info.beyondallreason.bar/data"
+  [ -d "$flatpak_data_dir" ] || {
+    echo ""
+    return
+  }
+
+  # Check each devtools symlink for flatpak exposure
+  local linked_outside=0
+  local -A link_map=(
+    [bar]="$flatpak_data_dir/games/Beyond-All-Reason.sdd"
+    [chobby]="$flatpak_data_dir/games/BYAR-Chobby.sdd"
+    [engine]="$flatpak_data_dir/engine/local-build"
+  )
+  local name link_path target
+  for name in bar chobby engine; do
+    link_path="${link_map[$name]}"
+    if [ -L "$link_path" ]; then
+      target="$(readlink "$link_path")"
+      case "$target" in
+        "$flatpak_data_dir"/*|"$HOME/.var/app/info.beyondallreason.bar"/*)
+          : ;;
+        *)
+          if [ "$linked_outside" -eq 0 ]; then
+            _warn "$name symlink target is outside Flatpak sandbox"
+            info "  $link_path -> $target"
+            linked_outside=1
+          else
+            info "  $name -> $target (also outside)"
+          fi
+          ;;
+      esac
+    fi
+  done
+
+  if [ "$linked_outside" -gt 0 ]; then
+    echo ""
+    warn "The Flatpak sandbox blocks the Spring engine from following symlinks"
+    warn "into folders it hasn't been granted access to."
+    warn "Please grant access to these folders with:"
+    warn "  flatpak override --user info.beyondallreason.bar --filesystem=$DEVTOOLS_DIR"
+  fi
+
+  echo ""
+}
+
+
 check_doctor_ports() {
   echo -e "${BOLD}Ports${NC}"
 
@@ -308,6 +373,7 @@ cmd_doctor() {
   check_doctor_deps
   check_doctor_env
   check_doctor_wsl
+  check_doctor_flatpak
   check_doctor_modules
   check_doctor_ports
   check_doctor_repos


### PR DESCRIPTION
### LLM disclosure 
Diagnosed by DeepSeek v4 Flash
Written by  DeepSeek v4 Flash
Reviewed by NortySpock

## Summary

Add a Flatpak section to `just doctor` that detects when BAR is installed via Flatpak and checks whether devtools symlinks inside the Flatpak data directory point outside the sandbox.

## Motivation

When BAR is installed via Flatpak, the Spring engine runs sandboxed. Symlinks created by `just link::create` (pointing from `~/.var/app/info.beyondallreason.bar/data/games/` into the devtools checkout) are valid from the host kernel's perspective, but the Flatpak sandbox blocks the engine from following them. The engine logs:

```
[FSA::GetFileModificationTime] error 'No such file or directory' ...
[IsPathOnSpinningDisk] Error 'No such file or directory' getting stat() ...
```

This was previously invisible to `just doctor` — no Flatpak-related checks existed.

## Changes

- **`scripts/doctor.sh`**: Added `check_doctor_flatpak()` function that:
  1. Exits early with `[ok] flatpak not installed` if Flatpak isn't present.
  2. Exits early with `[ok] flatpak installed, BAR not installed via flatpak` if BAR isn't a Flatpak install.
  3. Otherwise inspects the three devtools symlinks (`bar`, `chobby`, `engine`) under `~/.var/app/info.beyondallreason.bar/data/`. If any point outside the Flatpak sandbox, a warning is printed along with the exact `flatpak override --user` command needed to grant access.

- Wired the new check into `cmd_doctor()` between `check_doctor_wsl` and `check_doctor_modules`.

## Example output

With Flatpak + BAR installed + devtools symlinks:

```
Flatpak
[ok]    Flatpak 1.16.1, info.beyondallreason.bar installed
[warn]  bar symlink target is outside Flatpak sandbox
[info]    /home/user/.var/app/info.beyondallreason.bar/data/games/Beyond-All-Reason.sdd -> /home/user/hacknight/BAR-Devtools/Beyond-All-Reason

[info]  The Flatpak sandbox blocks the Spring engine from following
[info]  symlinks into directories it hasn't been granted access to.
[info]  Grant access with:
  flatpak override --user info.beyondallreason.bar --filesystem=/home/user/hacknight/BAR-Devtools
```

Without Flatpak:

```
Flatpak
[ok]    flatpak not installed
```

Partially addresses https://github.com/beyond-all-reason/BAR-Devtools/issues/47